### PR TITLE
Fix TypeScript file inclusion

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,10 @@
     "target": "es2019",
     "module": "commonjs",
     "outDir": "build",
-    "rootDir": "src",
     "alwaysStrict": true,
     "esModuleInterop": true
-  }
+  },
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
Correctly tells the TypeScript compiler to only include the `src` directory.

Refs https://github.com/libero/article-store/pull/6#discussion_r343194021.