### PR TITLE
Use JSON-LD context to make URIs absolute

### DIFF
--- a/src/routes/entry-point.ts
+++ b/src/routes/entry-point.ts
@@ -1,13 +1,15 @@
 import Router from '@koa/router';
 import { Context, Middleware, Next } from 'koa';
 import { schema } from 'rdf-namespaces';
-import url from 'url';
 import Routes from './index';
 
 export default (router: Router): Middleware => (
   async ({ request, response }: Context, next: Next): Promise<void> => {
     response.body = {
-      '@id': url.resolve(request.origin, router.url(Routes.EntryPoint, {})),
+      '@context': {
+        '@base': request.origin,
+      },
+      '@id': router.url(Routes.EntryPoint, {}),
       '@type': schema.EntryPoint,
       [schema.name]: { '@value': 'Article Store', '@language': 'en' },
     };


### PR DESCRIPTION
The Koa Router doesn't have a way to construct absolute URIs. Rather than constructing them manually everywhere, or looking at passing in a different function, the JSON-LD context can be used.