### PR TITLE
Use dummy router in middleware tests

### DIFF
--- a/test/routes/context.ts
+++ b/test/routes/context.ts
@@ -4,7 +4,7 @@ import Request from 'koa/lib/request';
 import Response from 'koa/lib/response';
 import { Request as IncomingMessage, Response as ServerResponse } from 'mock-http';
 
-export default (route: string): RouterContext => {
+export default (): RouterContext => {
   const request = Object.create(Request);
   const response = Object.create(Response);
   request.app = new Koa();
@@ -12,8 +12,11 @@ export default (route: string): RouterContext => {
   response.req = request.req;
   response.res = new ServerResponse();
 
-  const router = new Router();
-  router.get(route, `path-to/${route}`, jest.fn());
+  const router = {
+    url(name: string): string {
+      return `/path-to/${name}`;
+    },
+  } as unknown as Router;
 
   return { request, response, router } as RouterContext;
 };

--- a/test/routes/entry-point.test.ts
+++ b/test/routes/entry-point.test.ts
@@ -5,7 +5,7 @@ import runMiddleware from '../middleware';
 import createContext from './context';
 
 const makeRequest = async (next?: Next): Promise<Response> => {
-  const context = createContext('entry-point');
+  const context = createContext();
 
   return runMiddleware(entryPoint(context.router), context, next);
 };


### PR DESCRIPTION
Rather than declaring what routes this middleware depends on, this dummy implementation responds to any URL generatation requests.