### PR TITLE
Remove empty URL parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -680,9 +680,9 @@
       }
     },
     "@types/koa__router": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.1.tgz",
-      "integrity": "sha512-FdJsL2WILvLFD7GSWD0SR/HqSwqcAOzLB1N1Zb8yiC0k9VQ0IR6854EaLrkLs6OldhkFSMYbq5l8VkXC6DxBeg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.2.tgz",
+      "integrity": "sha512-3ZWfVAEcErHrZA31fWUC2YyZyAgoG4eKtQPy2XwBzdSpQealxjL7GcEEtGY925qPPs1wurW59qDl0KuRB39rrw==",
       "dev": true,
       "requires": {
         "@types/koa": "*"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/koa-compose": "^3.2.5",
     "@types/koa-logger": "^3.1.1",
     "@types/koa__cors": "^2.2.3",
-    "@types/koa__router": "^8.0.1",
+    "@types/koa__router": "^8.0.2",
     "@types/node": "^12.12.6",
     "@types/supertest": "^2.0.8",
     "@typescript-eslint/eslint-plugin": "^2.6.1",

--- a/src/routes/entry-point.ts
+++ b/src/routes/entry-point.ts
@@ -9,7 +9,7 @@ export default (router: Router): Middleware => (
       '@context': {
         '@base': request.origin,
       },
-      '@id': router.url(Routes.EntryPoint, {}),
+      '@id': router.url(Routes.EntryPoint),
       '@type': schema.EntryPoint,
       [schema.name]: { '@value': 'Article Store', '@language': 'en' },
     };


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40360 was merged, so the definition of `Router.url()` now correctly has the `params` argument as optional.