### PR TITLE
chore: Added no implicit any to compiler options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "outDir": "build",
     "alwaysStrict": true,
+    "noImplicitAny": true,
     "esModuleInterop": true
   },
   "include": [


### PR DESCRIPTION
Will prevent declarations (const, import, let, functional arguments etc.) being assigned to any when a type cannot be inferred. 

```typescript
function takesNumber(num) {
  // would throw compiler error
}
```

but will still allow inferred types, usually through generics:
```typescript
[1, 2, 3].map(num => {
  // num still inferred correctly as number
});

[1, 2, 'something'].map(num => {
  // num inferred as `number | string`
});
```

Depends on #23 