### PR TITLE
Added type for unknown error, based on input of http-errors library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -575,9 +575,9 @@
       "dev": true
     },
     "@types/http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha512-mzJX3tIbtadNZQIDbfA9eW+mAjww7GY7WYcfKDGB5SSXMAzI8KD+5fvyX5FqcKtns346+WGwAJJ8cPsDxMz0lw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-4KCE/agIcoQ9bIfa4sBxbZdnORzRjIw8JNQPLfqoNv7wQl/8f8mRbW68Q8wBsQFoJkPUHGlQYZ9sqi5WpfGSEQ==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/format-link-header": "^2.1.0",
-    "@types/http-errors": "^1.6.2",
+    "@types/http-errors": "^1.6.3",
     "@types/jest": "^24.0.22",
     "@types/jsonld": "^1.5.0",
     "@types/koa": "^2.0.52",

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -1,10 +1,6 @@
-import createError, { HttpError, CreateHttpError } from 'http-errors';
+import createError, { HttpError, UnknownError } from 'http-errors';
 import { Context, Middleware, Next } from 'koa';
 import { hydra } from 'rdf-namespaces';
-
-type UnknownError<T = CreateHttpError> = T extends (
-    (event: infer ErrorShape, ...args: unknown[]) => HttpError
-  ) ? ErrorShape : never;
 
 const handleHttpError = (error: HttpError, { response }: Context): void => {
   response.status = error.status;
@@ -20,8 +16,8 @@ const handleHttpError = (error: HttpError, { response }: Context): void => {
   response.type = 'jsonld';
 };
 
-const toHttpError = (error: unknown): HttpError => (
-  error instanceof HttpError ? error : createError(error as UnknownError)
+const toHttpError = (error: UnknownError): HttpError => (
+  error instanceof HttpError ? error : createError(error)
 );
 
 export default (): Middleware => (

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -1,6 +1,10 @@
-import createError, { HttpError } from 'http-errors';
+import createError, { HttpError, CreateHttpError } from 'http-errors';
 import { Context, Middleware, Next } from 'koa';
 import { hydra } from 'rdf-namespaces';
+
+type UnknownError<T = CreateHttpError> = T extends (
+    (event: infer ErrorShape, ...args: unknown[]) => HttpError
+  ) ? ErrorShape : never;
 
 const handleHttpError = (error: HttpError, { response }: Context): void => {
   response.status = error.status;
@@ -17,7 +21,7 @@ const handleHttpError = (error: HttpError, { response }: Context): void => {
 };
 
 const toHttpError = (error: unknown): HttpError => (
-  error instanceof HttpError ? error : createError(error)
+  error instanceof HttpError ? error : createError(error as UnknownError)
 );
 
 export default (): Middleware => (

--- a/test/context.ts
+++ b/test/context.ts
@@ -1,10 +1,11 @@
 import Router, { RouterContext } from '@koa/router';
+import { UnknownError } from 'http-errors';
 import Koa, { Context } from 'koa';
 import Request from 'koa/lib/request';
 import Response from 'koa/lib/response';
 import { Request as IncomingMessage, Response as ServerResponse } from 'mock-http';
 
-export type ErrorListener = (error: unknown, context: Context) => void;
+export type ErrorListener = (error: UnknownError, context: Context) => void;
 
 type Options = {
   errorListener?: ErrorListener;

--- a/test/middleware/error-handler.test.ts
+++ b/test/middleware/error-handler.test.ts
@@ -1,4 +1,4 @@
-import createHttpError from 'http-errors';
+import createHttpError, { UnknownError } from 'http-errors';
 import jsonld from 'jsonld';
 import { Response } from 'koa';
 import errorHandler from '../../src/middleware/error-handler';
@@ -11,7 +11,7 @@ const makeRequest = async (next?: Next, errorListener?: ErrorListener): Promise<
   return runMiddleware(errorHandler(), context, next);
 };
 
-const next = (error: unknown) => async (): Promise<void> => {
+const next = (error: UnknownError) => async (): Promise<void> => {
   throw error;
 };
 


### PR DESCRIPTION
This gives the `unknown` type a concrete type before being passed to the create error.

The type for UnknownError is computed as:
```typescript
type UnknownError = Error | string | number | { [key: string]: any };
```
From `createHttpError.CreateHttpError` types package. As this is not exported, there is a quick `infer` type that will grab this value, even if it changes.

```typescript
// `T extends ( ...` indicates that there is a ternary
type UnknownError<T = CreateHttpError> = T extends (
    // This expression is a generic shape of an input (in this case `CreateHttpError`)
    //  The `infer` keyword determines the true-ness of the statement
    (event: infer ErrorShape, ...args: unknown[]) => HttpError
  // When true, the value of the type is `ErrorShape` (a generic value, inferred above)
  // When false, the value is never and will error (same as the return type when throwing an exception)
  ) ? ErrorShape : never;
```