### PR TITLE
Allow running an arbitrary command on the app container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ sh: ## Open a shell on the app container
 	make exec command="sh"
 
 exec: ## Run a command on the app container
+	if [ -z "$(command)" ]; then \
+		echo "No command provided"; \
+		exit 1; \
+	fi; \
 	${DOCKER_COMPOSE} exec app $(command)
 
 logs: ## Show the containers' logs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL = help
-.PHONY: help install gitmodules build start stop wait-healthy sh logs watch lint fix test run dev prod
+.PHONY: help install gitmodules build start stop wait-healthy sh exec logs watch lint fix test run dev prod
 
 SHELL = /usr/bin/env bash
 
@@ -46,6 +46,10 @@ wait-healthy: ## Wait for the containers to be healthy
 
 sh: ## Open a shell on the app container
 	${DOCKER_COMPOSE} exec app sh
+	make exec command="sh"
+
+exec: ## Run a command on the app container
+	${DOCKER_COMPOSE} exec app $(command)
 
 logs: ## Show the containers' logs
 	${DOCKER_COMPOSE} logs

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ wait-healthy: ## Wait for the containers to be healthy
 	done
 
 sh: ## Open a shell on the app container
-	${DOCKER_COMPOSE} exec app sh
 	make exec command="sh"
 
 exec: ## Run a command on the app container


### PR DESCRIPTION
Adds `make exec` to run a command on the app container.

Extracted from https://github.com/libero/article-store/pull/33.