### PR TITLE
Fix node identifiers in the collection manages block

### DIFF
--- a/src/routes/article-list.ts
+++ b/src/routes/article-list.ts
@@ -13,8 +13,8 @@ export default (router: Router): Middleware => (
       '@type': hydra.Collection,
       [hydra.title]: { '@value': 'List of articles', '@language': 'en' },
       'http://www.w3.org/ns/hydra/core#manages': {
-        'http://www.w3.org/ns/hydra/core#property': rdf.type,
-        'http://www.w3.org/ns/hydra/core#object': schema.Article,
+        'http://www.w3.org/ns/hydra/core#property': { '@id': rdf.type },
+        'http://www.w3.org/ns/hydra/core#object': { '@id': schema.Article },
       },
       [hydra.totalItems]: 0,
       [hydra.member]: { '@list': [] },


### PR DESCRIPTION
Currently they are plain strings rather than identifiers.