### PR TITLE
Allow Dependabot to auto-merge non-major updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,10 @@ update_configs:
     commit_message:
       prefix: chore
       include_scope: true
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: 'semver:minor'
     default_labels:
       - ':recycle: Chore'
 
@@ -16,6 +20,10 @@ update_configs:
     commit_message:
       prefix: chore
       include_scope: true
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: 'semver:minor'
     default_labels:
       - ':recycle: Chore'
 
@@ -25,5 +33,9 @@ update_configs:
     commit_message:
       prefix: chore
       include_scope: true
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: 'semver:minor'
     default_labels:
       - ':recycle: Chore'

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -33,9 +33,5 @@ update_configs:
     commit_message:
       prefix: chore
       include_scope: true
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: 'semver:minor'
     default_labels:
       - ':recycle: Chore'


### PR DESCRIPTION
Dependabot will be opening quite a few PRs, this allows it to auto-merge minor and patch updates. 

There's always a chance that it will introduce problems even if the status checks all pass, but a human wouldn't have found it anyway...

Refs https://github.com/libero/article-store/pull/51#issuecomment-558090886.