### PR TITLE
Only build the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: minimal
 
 services: docker
 
+branches:
+  only:
+    - master
+
 env:
   global:
     - IMAGE_TAG=$TRAVIS_COMMIT


### PR DESCRIPTION
Pull requests should come from a fork, but Dependabot uses the origin repo. (And sometimes forks are accidentally not used, eg #45.) These are currently built twice (branch, and the pull request). This stops the branch itself being built.