### PR TITLE
Disable no-undef rule in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,9 @@ module.exports = {
     'jest',
   ],
   root: true,
+  rules: {
+    'no-undef': 'off',
+  },
   settings: {
     'import/resolver': {
       typescript: {


### PR DESCRIPTION
Disables the eslint `no-undef` rule as it doesn't work correctly with TypeScript, which catches the same problems anyway.

Refs https://github.com/typescript-eslint/typescript-eslint/issues/342.

Extracted from https://github.com/libero/article-store/pull/47.