### PR TITLE
Adds schema:Article to the API documentation

### DIFF
--- a/src/routes/api-documentation.ts
+++ b/src/routes/api-documentation.ts
@@ -105,7 +105,7 @@ export default (router: Router): Middleware => (
           [hydra.supportedProperty]: [
             {
               '@type': hydra.SupportedProperty,
-              [hydra.title]: { '@value': 'Name', '@language': 'en' },
+              [hydra.title]: { '@value': 'Title', '@language': 'en' },
               [hydra.property]: {
                 '@id': schema.name,
                 '@type': rdf.Property,

--- a/src/routes/api-documentation.ts
+++ b/src/routes/api-documentation.ts
@@ -98,6 +98,24 @@ export default (router: Router): Middleware => (
             },
           ],
         },
+        {
+          '@id': schema.Article,
+          '@type': hydra.Class,
+          [hydra.title]: { '@value': 'Article', '@language': 'en' },
+          [hydra.supportedProperty]: [
+            {
+              '@type': hydra.SupportedProperty,
+              [hydra.title]: { '@value': 'Name', '@language': 'en' },
+              [hydra.property]: {
+                '@id': schema.name,
+                '@type': rdf.Property,
+              },
+              [hydra.required]: true,
+              [hydra.readable]: true,
+              [hydra.writeable]: true,
+            },
+          ],
+        },
       ],
     };
     response.type = 'jsonld';


### PR DESCRIPTION
The article list, although always empty, references `schema:Article`. This adds it to the API documentation.

Extracted from https://github.com/libero/article-store/pull/47.