### PR TITLE
Make analyse.sh non-interactive

### DIFF
--- a/.travis/analyse.sh
+++ b/.travis/analyse.sh
@@ -9,4 +9,4 @@ trap finish EXIT
 
 make start wait-healthy
 
-make exec command="npx hydra-validator analyse http://localhost:8080/"
+make docker-compose command="exec -T npx hydra-validator analyse http://localhost:8080/"

--- a/.travis/analyse.sh
+++ b/.travis/analyse.sh
@@ -9,4 +9,4 @@ trap finish EXIT
 
 make start wait-healthy
 
-make docker-compose command="exec -T npx hydra-validator analyse http://localhost:8080/"
+make docker-compose command="exec -T app npx hydra-validator analyse http://localhost:8080/"

--- a/.travis/analyse.sh
+++ b/.travis/analyse.sh
@@ -9,4 +9,4 @@ trap finish EXIT
 
 make start wait-healthy
 
-make docker-compose command="exec -T app npx hydra-validator analyse http://localhost:8080/"
+make exec tty=0 command="npx hydra-validator analyse http://localhost:8080/"

--- a/.travis/analyse.sh
+++ b/.travis/analyse.sh
@@ -9,4 +9,4 @@ trap finish EXIT
 
 make start wait-healthy
 
-make exec tty=0 command="npx hydra-validator analyse http://localhost:8080/"
+make exec tty= command="npx hydra-validator analyse http://localhost:8080/"

--- a/Makefile
+++ b/Makefile
@@ -47,18 +47,13 @@ wait-healthy: ## Wait for the containers to be healthy
 sh: ## Open a shell on the app container
 	make exec command="sh"
 
-tty=1
-ifeq ($(tty), 0)
-	options=-T
-else
-	options=
-endif
+tty = 1
 exec: ## Run a command on the app container
 	if [ -z "$(command)" ]; then \
 		echo "No command provided"; \
 		exit 1; \
 	fi;
-	${DOCKER_COMPOSE} exec $(options) app $(command)
+	${DOCKER_COMPOSE} exec $(if $(tty),,-T) app $(command)
 
 logs: ## Show the containers' logs
 	${DOCKER_COMPOSE} logs

--- a/Makefile
+++ b/Makefile
@@ -47,19 +47,18 @@ wait-healthy: ## Wait for the containers to be healthy
 sh: ## Open a shell on the app container
 	make exec command="sh"
 
+tty=1
+ifeq ($(tty), 0)
+	options=-T
+else
+	options=
+endif
 exec: ## Run a command on the app container
 	if [ -z "$(command)" ]; then \
 		echo "No command provided"; \
 		exit 1; \
-	fi; \
-	${DOCKER_COMPOSE} exec app $(command)
-
-docker-compose: ## Run an arbitrary docker-compose command
-	if [ -z "$(command)" ]; then \
-		echo "No command provided"; \
-		exit 1; \
-	fi; \
-	${DOCKER_COMPOSE} $(command)
+	fi;
+	${DOCKER_COMPOSE} exec $(options) app $(command)
 
 logs: ## Show the containers' logs
 	${DOCKER_COMPOSE} logs

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,13 @@ exec: ## Run a command on the app container
 	fi; \
 	${DOCKER_COMPOSE} exec app $(command)
 
+docker-compose: ## Run an arbitrary docker-compose command
+	if [ -z "$(command)" ]; then \
+		echo "No command provided"; \
+		exit 1; \
+	fi; \
+	${DOCKER_COMPOSE} $(command)
+
 logs: ## Show the containers' logs
 	${DOCKER_COMPOSE} logs
 


### PR DESCRIPTION
Extracted from https://github.com/libero/article-store/pull/74

`docker-compose exec` (without `-T`) is nice for interactive use, but is not friendly to automated systems running scripts such as Github Actions.

Typical failure:
```
docker-compose --file .docker/docker-compose.yml --file
.docker/docker-compose.dev.yml exec app npx hydra-validator analyse
http://localhost:8080/
the input device is not a TTY
```