### PR TITLE
Let MAKEFLAGS be passed through the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## Display this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install dependencies locally
-	make --jobs=2 $(MAKEFLAGS) node_modules gitmodules
+	$(MAKE) node_modules gitmodules
 
 node_modules: package.json package-lock.json
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## Display this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install dependencies locally
-	make node_modules gitmodules
+	$(MAKE) node_modules gitmodules
 
 node_modules: package.json package-lock.json
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## Display this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install dependencies locally
-	$(MAKE) node_modules gitmodules
+	make node_modules gitmodules
 
 node_modules: package.json package-lock.json
 	npm install


### PR DESCRIPTION
`make dev` is broken for me on `master`:
```
$ make dev
make --jobs=4 install build stop
make[1]: Entering directory '/home/giorgio/code/article-store'
make --jobs=2 w -j --jobserver-fds=3,4 node_modules gitmodules
docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml build
docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml down
make[2]: Entering directory '/home/giorgio/code/article-store'
make[2]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[2]: *** No rule to make target 'w'. Stop.
make[2]: Leaving directory '/home/giorgio/code/article-store'
Makefile:19: recipe for target 'install' failed
...
make[1]: Leaving directory '/home/giorgio/code/article-store'
Makefile:81: recipe for target 'dev' failed
make: *** [dev] Error 2
```
This is because when `install` is called recursively, `MAKEFLAGS` can be seen with an `env` command to evaluate to:
```
MAKEFLAGS=w -j --jobserver-fds=3,4
```
It is set as an environment variable, therefore does not need to be passed on the command line.