### PR TITLE
chore(deps-dev): upgrade hypermedia-app to 0.12.2

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - '8080:8080'
   console:
-    image: tpluscode/hypermedia-app:version-0.12.1
+    image: tpluscode/hypermedia-app:version-0.12.2
     environment:
       API_ENTRYPOINTS: '{ "http://localhost:8080/": "Article Store" }'
       BASE_URL: http://localhost:8080/


### PR DESCRIPTION
Contains https://github.com/hypermedia-app/generic.hypermedia.app/pull/47 which lets Ctrl+C immediately stop the container without the 10 second delay.