### PR TITLE
Use `$(MAKE)` consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ wait-healthy: ## Wait for the containers to be healthy
 	done
 
 sh: ## Open a shell on the app container
-	make exec command="sh"
+	$(MAKE) exec command="sh"
 
 tty = 1
 exec: ## Run a command on the app container
@@ -78,10 +78,10 @@ run:
 
 dev: export TARGET = dev
 dev: ## Build and runs the container for development
-	make --jobs=4 install build stop
-	make run
+	$(MAKE) --jobs=4 install build stop
+	$(MAKE) run
 
 prod: export TARGET = prod
 prod: ## Builds and runs the container for production
-	make --jobs=2 build stop
-	make run
+	$(MAKE) --jobs=2 build stop
+	$(MAKE) run


### PR DESCRIPTION
Allows make to pass down flags consistently, e.g. for `-n` for dry runs.

Before:
```
$ make -n dev
make --jobs=4 install build stop
make run
```

After:
```
$ make -n dev
make --jobs=4 install build stop
make[1]: Entering directory '/home/giorgio/code/article-store'
make node_modules gitmodules
docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml build
docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml down
make[2]: Entering directory '/home/giorgio/code/article-store'
make[2]: 'node_modules' is up to date.
git submodule update --init --recursive
make[2]: Leaving directory '/home/giorgio/code/article-store'
make[1]: Leaving directory '/home/giorgio/code/article-store'
make run
make[1]: Entering directory '/home/giorgio/code/article-store'
docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml up --abort-on-container-exit --exit-code-from app; docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml down
make[1]: Leaving directory '/home/giorgio/code/article-store'
```