### PR TITLE
Turn install submake into prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ export TARGET
 help: ## Display this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-install: ## Install dependencies locally
-	$(MAKE) node_modules gitmodules
+install: node_modules gitmodules ## Install dependencies locally
 
 node_modules: package.json package-lock.json
 	npm install


### PR DESCRIPTION
Doesn't affect their parallelism in terms of total `--jobs` passed in by `make dev`.