### PR TITLE
Only use id in create-article name if defined

### DIFF
--- a/test/create-article.ts
+++ b/test/create-article.ts
@@ -3,7 +3,7 @@ import { Iri, JsonLdObj } from 'jsonld/jsonld-spec';
 
 const isNotUndefined = (arg: unknown): boolean => arg !== undefined;
 
-export default (id?: Iri, name = `Article ${id}`): JsonLdObj => (
+export default (id?: Iri, name = id ? `Article ${id}` : 'Article'): JsonLdObj => (
   deepFilter({
     '@id': id,
     '@type': 'http://schema.org/Article',

--- a/test/create-article.ts
+++ b/test/create-article.ts
@@ -3,7 +3,7 @@ import { Iri, JsonLdObj } from 'jsonld/jsonld-spec';
 
 const isNotUndefined = (arg: unknown): boolean => arg !== undefined;
 
-export default (id?: Iri, name = id ? `Article ${id}` : 'Article'): JsonLdObj => (
+export default (id?: Iri, name = `Article ${id}`): JsonLdObj => (
   deepFilter({
     '@id': id,
     '@type': 'http://schema.org/Article',

--- a/test/routes/add-article.test.ts
+++ b/test/routes/add-article.test.ts
@@ -23,6 +23,7 @@ describe('add article', (): void => {
 
     expect(response.status).toBe(204);
     expect(await articles.count()).toBe(1);
+    expect([...articles][0]['http://schema.org/name']).toEqual('Article');
   });
 
   it('should throw an error if id is already set', async (): Promise<void> => {


### PR DESCRIPTION
Currently the `schema:name` is set to `Article undefined` if `createArticle()` is called.