### PR TITLE
Separate API documentation link middleware from the router

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import apiDocumentation from './middleware/api-documentation';
 import errorHandler from './middleware/error-handler';
 import routing from './middleware/routing';
 import createRouter from './router';
+import Routes from './routes';
 
 export default (articles: Articles): Koa => {
   const app = new Koa();
@@ -21,7 +22,7 @@ export default (articles: Articles): Koa => {
   app.use(cors({
     exposeHeaders: ['Link'],
   }));
-  app.use(apiDocumentation(router));
+  app.use(apiDocumentation(router.url(Routes.ApiDocumentation)));
   app.use(errorHandler());
   app.use(routing(router));
 

--- a/src/middleware/api-documentation.ts
+++ b/src/middleware/api-documentation.ts
@@ -1,17 +1,15 @@
-import Router from '@koa/router';
 import formatLinkHeader from 'format-link-header';
 import { Context, Middleware, Next } from 'koa';
 import { hydra } from 'rdf-namespaces';
 import url from 'url';
-import Routes from '../routes';
 
-export default (router: Router): Middleware => (
+export default (path: string): Middleware => (
   async ({ request, response }: Context, next: Next): Promise<void> => {
     await next();
 
     const link = {
       rel: hydra.apiDocumentation,
-      url: url.resolve(request.origin, router.url(Routes.ApiDocumentation)),
+      url: url.resolve(request.origin, path),
     };
 
     response.append('Link', formatLinkHeader({ hydra: link }));

--- a/test/middleware/api-documentation.test.ts
+++ b/test/middleware/api-documentation.test.ts
@@ -4,11 +4,9 @@ import apiDocumentation from '../../src/middleware/api-documentation';
 import createContext from '../context';
 import runMiddleware from '../middleware';
 
-const makeRequest = async (): Promise<Response> => {
-  const context = createContext();
-
-  return runMiddleware(apiDocumentation(context.router), context);
-};
+const makeRequest = async (): Promise<Response> => (
+  runMiddleware(apiDocumentation('/path-to/api-documentation'), createContext())
+);
 
 describe('API documentation middleware', (): void => {
   it('adds the API documentation link', async (): Promise<void> => {


### PR DESCRIPTION
Reduces coupling, as the path doesn't have to be recomputed.

Refs https://github.com/libero/article-store/pull/60#discussion_r354792149.