### PR TITLE
Improve link to latest CI run on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Libero Article Store
 ====================
 
 [![Build Status](https://travis-ci.com/libero/article-store.svg?branch=master)](https://travis-ci.com/libero/article-store)
-[![Build Status](https://github.com/libero/article-store/actions?query=branch%3Amaster+workflow%3ACI)](https://github.com/libero/article-store/actions?query=branch%3Amaster)
+[![Build Status](https://github.com/libero/article-store/workflows/CI/badge.svg?branch=master)](https://github.com/libero/article-store/actions?query=branch%3Amaster+workflow%3ACI)
 
 Implementation of a [Libero API](https://libero.pub/api).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Libero Article Store
 ====================
 
 [![Build Status](https://travis-ci.com/libero/article-store.svg?branch=master)](https://travis-ci.com/libero/article-store)
-[![Build Status](https://github.com/libero/article-store/workflows/CI/badge.svg?branch=master)](https://github.com/libero/article-store/actions?query=branch%3Amaster)
+[![Build Status](https://github.com/libero/article-store/actions?query=branch%3Amaster+workflow%3ACI)](https://github.com/libero/article-store/actions?query=branch%3Amaster)
 
 Implementation of a [Libero API](https://libero.pub/api).
 


### PR DESCRIPTION
The [README](https://github.com/libero/article-store/blob/master/README.md) shows the correct badge but the link is for a list of all workflows, which may not be CI-related in general.