### PR TITLE
Prevent `if` echoing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ stop: ## Stop the containers
 	${DOCKER_COMPOSE} down
 
 wait-healthy: ## Wait for the containers to be healthy
-	services=($$(${DOCKER_COMPOSE} ps --quiet)); \
+	@services=($$(${DOCKER_COMPOSE} ps --quiet)); \
 	if [ $${#services[@]} -eq 0 ]; then \
 		echo "No containers running"; \
 		exit 1; \
@@ -48,7 +48,7 @@ sh: ## Open a shell on the app container
 
 tty = 1
 exec: ## Run a command on the app container
-	if [ -z "$(command)" ]; then \
+	@if [ -z "$(command)" ]; then \
 		echo "No command provided"; \
 		exit 1; \
 	fi;


### PR DESCRIPTION
Otherwise the full body of the `if` is printed even if its contents are not executed.

Before:

```
$ make exec
if [ -z "" ]; then \
        echo "No command provided"; \
        exit 1; \
fi;
No command provided
Makefile:51: recipe for target 'exec' failed
make: *** [exec] Error 1
$ make exec command=ls
if [ -z "ls" ]; then \
        echo "No command provided"; \
        exit 1; \
fi;
docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml exec  app ls
LICENSE.md         node_modules       package.json       test
jest.config.js     package-lock.json  src                tsconfig.json
```

After:

```
$ make exec
No command provided
Makefile:51: recipe for target 'exec' failed
make: *** [exec] Error 1
$ make exec command=ls
docker-compose --file .docker/docker-compose.yml --file .docker/docker-compose.dev.yml exec  app ls
LICENSE.md         node_modules       package.json       test
jest.config.js     package-lock.json  src                tsconfig.json
```