### PR TITLE
Disable @typescript-eslint/no-explicit-an rule for tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,16 @@ module.exports = {
     'plugin:import/typescript',
     'plugin:jest/recommended',
   ],
+  overrides: [
+    {
+      files: [
+        '*.test.ts',
+      ],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+      },
+    },
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2019,


### PR DESCRIPTION
There are instances where in test scenarios we want to be able to ensure that we can handle different cases that mean we are passing `undefined` or other types to the same parameter.

See: https://github.com/libero/article-store/pull/88/files#r355966492

Rather than setting a `eslint-disable-next-line` note in each instance we should just disable the rule for all test files.