### PR TITLE
Allow empty response bodies

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import bodyParser from 'koa-bodyparser';
 import logger from 'koa-logger';
 import Articles from './articles';
 import apiDocumentationLink from './middleware/api-documentation-link';
+import emptyResponse from './middleware/empty-response';
 import errorHandler from './middleware/error-handler';
 import jsonld from './middleware/jsonld';
 import routing from './middleware/routing';
@@ -28,6 +29,7 @@ export default (
   app.context.router = router;
 
   app.use(logger());
+  app.use(emptyResponse());
   app.use(bodyParser({
     extendTypes: {
       json: ['application/ld+json'],

--- a/src/middleware/empty-response.ts
+++ b/src/middleware/empty-response.ts
@@ -1,16 +1,20 @@
-import { Context, Middleware, Next } from 'koa';
+import {
+  Context, Middleware, Next, Response,
+} from 'koa';
+
+const makeResponseEmpty = (response: Response): void => {
+  response.body = '';
+  response.remove('Content-Length');
+  response.remove('Content-Type');
+  response.remove('Transfer-Encoding');
+};
 
 export default (): Middleware => (
   async ({ response }: Context, next: Next): Promise<void> => {
     await next();
 
-    if (response.body !== undefined) {
-      return;
+    if (response.body === undefined) {
+      makeResponseEmpty(response);
     }
-
-    response.body = '';
-    response.remove('Content-Length');
-    response.remove('Content-Type');
-    response.remove('Transfer-Encoding');
   }
 );

--- a/src/middleware/empty-response.ts
+++ b/src/middleware/empty-response.ts
@@ -6,7 +6,6 @@ const makeResponseEmpty = (response: Response): void => {
   response.body = '';
   response.remove('Content-Length');
   response.remove('Content-Type');
-  response.remove('Transfer-Encoding');
 };
 
 export default (): Middleware => (

--- a/src/middleware/empty-response.ts
+++ b/src/middleware/empty-response.ts
@@ -1,0 +1,16 @@
+import { Context, Middleware, Next } from 'koa';
+
+export default (): Middleware => (
+  async ({ response }: Context, next: Next): Promise<void> => {
+    await next();
+
+    if (response.body !== undefined) {
+      return;
+    }
+
+    response.body = '';
+    response.remove('Content-Length');
+    response.remove('Content-Type');
+    response.remove('Transfer-Encoding');
+  }
+);

--- a/test/middleware/empty-response.test.ts
+++ b/test/middleware/empty-response.test.ts
@@ -18,20 +18,17 @@ describe('Empty response middleware', (): void => {
     const next = async ({ response }: Context): Promise<void> => {
       response.set('Content-Length', '100');
       response.set('Content-Type', 'content/type');
-      response.set('Transfer-Encoding', 'identity');
     };
 
     const response = await makeRequest(next);
 
     expect(response.headers).not.toHaveProperty('content-length');
     expect(response.headers).not.toHaveProperty('content-type');
-    expect(response.headers).not.toHaveProperty('transfer-encoding');
   });
 
   it('does nothing if there is a body', async (): Promise<void> => {
     const next = async ({ response }: Context): Promise<void> => {
       response.body = 'body content';
-      response.set('Transfer-Encoding', 'identity');
     };
 
     const response = await makeRequest(next);
@@ -39,6 +36,5 @@ describe('Empty response middleware', (): void => {
     expect(response.body).toBe('body content');
     expect(response.headers).toHaveProperty('content-length');
     expect(response.headers).toHaveProperty('content-type');
-    expect(response.headers).toHaveProperty('transfer-encoding');
   });
 });

--- a/test/middleware/empty-response.test.ts
+++ b/test/middleware/empty-response.test.ts
@@ -1,0 +1,46 @@
+import { Context, Response } from 'koa';
+import emptyResponse from '../../src/middleware/empty-response';
+import createContext from '../context';
+import runMiddleware, { Next } from '../middleware';
+
+const makeRequest = async (next?: Next): Promise<Response> => (
+  runMiddleware(emptyResponse(), createContext(), next)
+);
+
+describe('Empty response middleware', (): void => {
+  it('sets an empty string body if it has not been set', async (): Promise<void> => {
+    const response = await makeRequest();
+
+    expect(response.body).toBe('');
+  });
+
+  it('removes redundant headers if no body has been set', async (): Promise<void> => {
+    const next = async ({ response }: Context): Promise<void> => {
+      response.set('Content-Length', '100');
+      response.set('Content-Type', 'content/type');
+      response.set('Transfer-Encoding', 'identity');
+    };
+
+    const response = await makeRequest(next);
+
+    expect(response.get('Content-Length')).toHaveLength(0);
+    expect(response.get('Content-Type')).toHaveLength(0);
+    expect(response.get('Transfer-Encoding')).toHaveLength(0);
+  });
+
+  it('does nothing if there is a body', async (): Promise<void> => {
+    const next = async ({ response }: Context): Promise<void> => {
+      response.body = 'body content';
+      response.set('Content-Length', '100');
+      response.set('Content-Type', 'content/type');
+      response.set('Transfer-Encoding', 'identity');
+    };
+
+    const response = await makeRequest(next);
+
+    expect(response.body).toBe('body content');
+    expect(response.get('Content-Length')).toBe('100');
+    expect(response.get('Content-Type')).toBe('content/type');
+    expect(response.get('Transfer-Encoding')).toBe('identity');
+  });
+});

--- a/test/middleware/empty-response.test.ts
+++ b/test/middleware/empty-response.test.ts
@@ -23,24 +23,22 @@ describe('Empty response middleware', (): void => {
 
     const response = await makeRequest(next);
 
-    expect(response.get('Content-Length')).toHaveLength(0);
-    expect(response.get('Content-Type')).toHaveLength(0);
-    expect(response.get('Transfer-Encoding')).toHaveLength(0);
+    expect(response.headers).not.toHaveProperty('content-length');
+    expect(response.headers).not.toHaveProperty('content-type');
+    expect(response.headers).not.toHaveProperty('transfer-encoding');
   });
 
   it('does nothing if there is a body', async (): Promise<void> => {
     const next = async ({ response }: Context): Promise<void> => {
       response.body = 'body content';
-      response.set('Content-Length', '100');
-      response.set('Content-Type', 'content/type');
       response.set('Transfer-Encoding', 'identity');
     };
 
     const response = await makeRequest(next);
 
     expect(response.body).toBe('body content');
-    expect(response.get('Content-Length')).toBe('100');
-    expect(response.get('Content-Type')).toBe('content/type');
-    expect(response.get('Transfer-Encoding')).toBe('identity');
+    expect(response.headers).toHaveProperty('content-length');
+    expect(response.headers).toHaveProperty('content-type');
+    expect(response.headers).toHaveProperty('transfer-encoding');
   });
 });


### PR DESCRIPTION
Koa [sets the body of a response as the status message](https://github.com/koajs/koa/blob/ed84ee50da8ae3cd08056f944d061e00d06ed87f/lib/application.js#L239-L251) if it hasn't been explicitly set and it's not a regular empty response (eg `204 No Content`). This prevents it from happening.

(This is expected behaviour of Koa, but not of this app, so I'm calling it a bug.)

Extracted from https://github.com/libero/article-store/pull/104.