### PR TITLE
Use 201 Created rather than 204 No Content

### DIFF
--- a/src/routes/add-article.ts
+++ b/src/routes/add-article.ts
@@ -5,11 +5,15 @@ import { JsonLdArray } from 'jsonld/jsonld-spec';
 import { Next } from 'koa';
 import { schema } from 'rdf-namespaces';
 import uniqueString from 'unique-string';
+import url from 'url';
 import { AppContext, AppMiddleware } from '../app';
 import NotAnArticle from '../errors/not-an-article';
+import Routes from './index';
 
 export default (): AppMiddleware => (
-  async ({ articles, request, response }: AppContext, next: Next): Promise<void> => {
+  async ({
+    articles, request, response, router,
+  }: AppContext, next: Next): Promise<void> => {
     const [article] = await jsonld.expand(request.body) as JsonLdArray;
     if ('@id' in article) {
       throw new createHttpError.Forbidden(`Article IDs must not be set ('${article['@id']}' was given)`);
@@ -30,7 +34,8 @@ export default (): AppMiddleware => (
       throw error;
     }
 
-    response.status = constants.HTTP_STATUS_NO_CONTENT;
+    response.status = constants.HTTP_STATUS_CREATED;
+    response.set('Location', url.resolve(request.origin, router.url(Routes.ArticleList)));
 
     await next();
   }

--- a/src/routes/api-documentation.ts
+++ b/src/routes/api-documentation.ts
@@ -61,7 +61,7 @@ export default (): AppMiddleware => (
               [hydra.returns]: { '@id': owl.Nothing },
               [hydra.possibleStatus]: [
                 {
-                  [hydra.statusCode]: constants.HTTP_STATUS_NO_CONTENT,
+                  [hydra.statusCode]: constants.HTTP_STATUS_CREATED,
                   [hydra.description]: { '@value': 'If the article was added successfully', '@language': 'en' },
                 },
               ],

--- a/test/routes/add-article.test.ts
+++ b/test/routes/add-article.test.ts
@@ -21,7 +21,8 @@ describe('add article', (): void => {
     const articles = new InMemoryArticles();
     const response = await makeRequest(createArticle(), undefined, articles);
 
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(201);
+    expect(response.get('Location')).toBe('http://example.com/path-to/article-list');
     expect(await articles.count()).toBe(1);
     expect([...articles][0]['http://schema.org/name']).toEqual([{ '@value': 'Article' }]);
   });


### PR DESCRIPTION
Currently adding a new article sees a `204 No Content` response. This was temporary as the articles aren't currently separate resources. However, it doesn't tell clients to go back to the collection. This changes the response to `201 Created` and sets the `Location` header.

Relies on #111 to make the body actually empty.

Extracted from #104.