### PR TITLE
Refine CODEOWNERS to include Infrastructure Reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 * @libero/node-js-reviewers
 /.docker/* @libero/infrastructure-reviewers
+/.dockerignore @libero/infrastructure-reviewers
 /.github/* @libero/infrastructure-reviewers
+/.scripts @libero/infrastructure-reviewers
 /Dockerfile @libero/infrastructure-reviewers
 /Makefile @libero/infrastructure-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @libero/node-js-reviewers
-/.docker/* @libero/infrastructure-reviewers
+/.docker/ @libero/infrastructure-reviewers
 /.dockerignore @libero/infrastructure-reviewers
-/.github/* @libero/infrastructure-reviewers
+/.github/ @libero/infrastructure-reviewers
 /.scripts @libero/infrastructure-reviewers
 /Dockerfile @libero/infrastructure-reviewers
 /Makefile @libero/infrastructure-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @libero/node-js-reviewers
-.docker/* @libero/infrastructure-reviewers
-.github/* @libero/infrastructure-reviewers
-Dockerfile @libero/infrastructure-reviewers
-Makefile @libero/infrastructure-reviewers
+/.docker/* @libero/infrastructure-reviewers
+/.github/* @libero/infrastructure-reviewers
+/Dockerfile @libero/infrastructure-reviewers
+/Makefile @libero/infrastructure-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 * @libero/node-js-reviewers
-.github/* @libero/infrastructure-reviewers
 .docker/* @libero/infrastructure-reviewers
+.github/* @libero/infrastructure-reviewers
+Dockerfile @libero/infrastructure-reviewers
+Makefile @libero/infrastructure-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @libero/node-js-reviewers
+.github/* @libero/infrastructure-reviewers
+.docker/* @libero/infrastructure-reviewers


### PR DESCRIPTION
During https://github.com/libero/publisher/issues/310 [Node.js Reviewers](https://github.com/orgs/libero/teams/node-js-reviewers) were continuously requested for on scripts that aren't really related.