### PR TITLE
Add operation types

### DIFF
--- a/src/routes/api-documentation.ts
+++ b/src/routes/api-documentation.ts
@@ -21,7 +21,7 @@ export default (): AppMiddleware => (
           '@type': hydra.Class,
           [hydra.title]: { '@value': 'API entry point', '@language': 'en' },
           [hydra.supportedOperation]: {
-            '@type': [hydra.Operation, schema.ViewAction],
+            '@type': [hydra.Operation, schema.DownloadAction],
             [hydra.title]: { '@value': 'Get the entry point', '@language': 'en' },
             [hydra.method]: { '@value': 'GET' },
             [hydra.expects]: { '@id': owl.Nothing },
@@ -47,7 +47,7 @@ export default (): AppMiddleware => (
           [hydra.title]: { '@value': 'Collection', '@language': 'en' },
           [hydra.supportedOperation]: [
             {
-              '@type': [hydra.Operation, schema.ViewAction],
+              '@type': [hydra.Operation, schema.DownloadAction],
               [hydra.title]: { '@value': 'Get the collection', '@language': 'en' },
               [hydra.method]: { '@value': 'GET' },
               [hydra.expects]: { '@id': owl.Nothing },

--- a/src/routes/api-documentation.ts
+++ b/src/routes/api-documentation.ts
@@ -21,7 +21,7 @@ export default (): AppMiddleware => (
           '@type': hydra.Class,
           [hydra.title]: { '@value': 'API entry point', '@language': 'en' },
           [hydra.supportedOperation]: {
-            '@type': hydra.Operation,
+            '@type': [hydra.Operation, schema.ViewAction],
             [hydra.title]: { '@value': 'Get the entry point', '@language': 'en' },
             [hydra.method]: { '@value': 'GET' },
             [hydra.expects]: { '@id': owl.Nothing },
@@ -47,14 +47,14 @@ export default (): AppMiddleware => (
           [hydra.title]: { '@value': 'Collection', '@language': 'en' },
           [hydra.supportedOperation]: [
             {
-              '@type': hydra.Operation,
+              '@type': [hydra.Operation, schema.ViewAction],
               [hydra.title]: { '@value': 'Get the collection', '@language': 'en' },
               [hydra.method]: { '@value': 'GET' },
               [hydra.expects]: { '@id': owl.Nothing },
               [hydra.returns]: { '@id': hydra.Collection },
             },
             {
-              '@type': hydra.Operation,
+              '@type': [hydra.Operation, schema.AddAction],
               [hydra.title]: { '@value': 'Add an article', '@language': 'en' },
               [hydra.method]: { '@value': 'POST' },
               [hydra.expects]: { '@id': schema.Article },


### PR DESCRIPTION
Adds Schema.org operation types to the API.

Extracted from https://github.com/libero/article-store/pull/104.