### PR TITLE
Remove redundant JSON-LD prefix

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,6 @@ export default (
     hydra: 'http://www.w3.org/ns/hydra/core#',
     owl: 'http://www.w3.org/2002/07/owl#',
     rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-    rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
     schema: 'http://schema.org/',
   }));
   app.use(apiDocumentationLink(apiDocumentationPath));


### PR DESCRIPTION
Usage was removed in https://github.com/libero/article-store/pull/48.