### PR TITLE
Remove RDF from the Hydra link header relation type

### DIFF
--- a/src/middleware/api-documentation-link.ts
+++ b/src/middleware/api-documentation-link.ts
@@ -1,6 +1,5 @@
 import formatLinkHeader from 'format-link-header';
 import { Context, Middleware, Next } from 'koa';
-import { hydra } from 'rdf-namespaces';
 import url from 'url';
 
 export default (path: string): Middleware => (
@@ -8,7 +7,7 @@ export default (path: string): Middleware => (
     await next();
 
     const link = {
-      rel: hydra.apiDocumentation,
+      rel: 'http://www.w3.org/ns/hydra/core#apiDocumentation',
       url: url.resolve(request.origin, path),
     };
 


### PR DESCRIPTION
The value for the relation type is the same as `Hydra: apiDocumentation`, but isn't RDF so shouldn't use an RDF library.

Refs https://github.com/libero/article-store/pull/115#discussion_r357824304.