### PR TITLE
Use RDF/JS terms instead of JSON-LD strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -453,6 +453,14 @@
         }
       }
     },
+    "@rdfjs/data-model": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.2.tgz",
+      "integrity": "sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==",
+      "requires": {
+        "@types/rdf-js": "^2.0.1"
+      }
+    },
     "@types/accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
@@ -723,8 +731,7 @@
     "@types/node": {
       "version": "12.12.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
-      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
-      "dev": true
+      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA=="
     },
     "@types/parse-link-header": {
       "version": "1.0.0",
@@ -737,6 +744,14 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
+    },
+    "@types/rdf-js": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.7.tgz",
+      "integrity": "sha512-VJjcUbg+BKJj273lmiO5mqd5A2Eb5HEdd/DJHZP9h4PgLu+BV6/6zs3OcwiK7OCHpMjP5j/SM7gY8hyX0KIw3Q==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/serve-static": {
       "version": "1.13.3",
@@ -6006,6 +6021,14 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/rdf-namespaces/-/rdf-namespaces-1.7.0.tgz",
       "integrity": "sha512-t8cvZRjRRd61ZSQl+zyNcwXy+xAU/WzCRZZaC6+s9Na47F+hvt1hZge7Qkr4Di5TI6em7QYWTSiPbDc5d9EZDw=="
+    },
+    "rdf-string": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.3.1.tgz",
+      "integrity": "sha512-Pcw6aZRfto2cZodK5kSqFZW8mz6nfKLxSfjOSrTi5ajb2CSIwzqGx7UniysgKoV2i7tQL5dpPgCgY80upCiRUw==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1"
+      }
     },
     "react-is": {
       "version": "16.11.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@koa/cors": "^3.0.0",
     "@koa/router": "^8.0.5",
+    "@rdfjs/data-model": "^1.1.2",
     "content-type": "^1.0.4",
     "format-link-header": "^2.1.0",
     "http-errors": "^1.7.3",
@@ -13,6 +14,7 @@
     "koa-compose": "^4.1.0",
     "koa-logger": "^3.2.1",
     "rdf-namespaces": "^1.7.0",
+    "rdf-string": "^1.3.1",
     "unique-string": "^2.0.0"
   },
   "devDependencies": {
@@ -30,6 +32,7 @@
     "@types/koa__router": "^8.0.2",
     "@types/node": "^12.12.21",
     "@types/parse-link-header": "^1.0.0",
+    "@types/rdf-js": "^2.0.7",
     "@types/supertest": "^2.0.8",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",

--- a/src/adaptors/in-memory-articles.ts
+++ b/src/adaptors/in-memory-articles.ts
@@ -1,43 +1,45 @@
-import { Iri, JsonLdObj } from 'jsonld/jsonld-spec';
+import { JsonLdObj } from 'jsonld/jsonld-spec';
+import { BlankNode, Term } from 'rdf-js';
 import { schema } from 'rdf-namespaces';
+import { stringToTerm, termToString } from 'rdf-string';
 import Articles from '../articles';
 import ArticleNotFound from '../errors/article-not-found';
 import NotAnArticle from '../errors/not-an-article';
 
 export default class InMemoryArticles implements Articles {
-  private articles: { [key: string]: [Iri, JsonLdObj] } = {};
+  private articles: { [id: string]: [BlankNode, JsonLdObj] } = {};
 
-  async set(id: Iri, article: JsonLdObj): Promise<void> {
+  async set(id: BlankNode, article: JsonLdObj): Promise<void> {
     const types = [].concat(article['@type'] || []);
 
-    if (!(types.includes(schema.Article)) || article['@id'] !== id) {
-      throw new NotAnArticle(types);
+    if (!(types.includes(schema.Article)) || article['@id'] !== termToString(id)) {
+      throw new NotAnArticle(types.map((type: string): Term => stringToTerm(type)));
     }
 
-    this.articles[id] = [id, article];
+    this.articles[id.value] = [id, article];
   }
 
-  async get(id: Iri): Promise<JsonLdObj> {
-    if (!(id in this.articles)) {
+  async get(id: BlankNode): Promise<JsonLdObj> {
+    if (!(id.value in this.articles)) {
       throw new ArticleNotFound(id);
     }
 
-    return this.articles[id][1];
+    return this.articles[id.value][1];
   }
 
-  async remove(id: Iri): Promise<void> {
-    delete this.articles[id];
+  async remove(id: BlankNode): Promise<void> {
+    delete this.articles[id.value];
   }
 
-  async contains(id: Iri): Promise<boolean> {
-    return id in this.articles;
+  async contains(id: BlankNode): Promise<boolean> {
+    return id.value in this.articles;
   }
 
   async count(): Promise<number> {
     return Object.values(this.articles).length;
   }
 
-  async* [Symbol.asyncIterator](): AsyncIterator<[Iri, JsonLdObj]> {
+  async* [Symbol.asyncIterator](): AsyncIterator<[BlankNode, JsonLdObj]> {
     yield* Object.values(this.articles);
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import Router, { RouterContext } from '@koa/router';
 import Koa, { DefaultState, Middleware } from 'koa';
 import bodyParser from 'koa-bodyparser';
 import logger from 'koa-logger';
+import { DataFactory } from 'rdf-js';
 import Articles from './articles';
 import apiDocumentationLink from './middleware/api-documentation-link';
 import emptyResponse from './middleware/empty-response';
@@ -14,6 +15,7 @@ export type AppState = DefaultState;
 
 export type AppContext = RouterContext<AppState, {
   articles: Articles;
+  dataFactory: DataFactory;
 }>;
 
 export type AppMiddleware = Middleware<AppState, AppContext>;
@@ -22,10 +24,12 @@ export default (
   articles: Articles,
   router: Router<AppState, AppContext>,
   apiDocumentationPath: string,
+  dataFactory: DataFactory,
 ): Koa<AppState, AppContext> => {
   const app = new Koa<AppState, AppContext>();
 
   app.context.articles = articles;
+  app.context.dataFactory = dataFactory;
   app.context.router = router;
 
   app.use(logger());

--- a/src/articles.ts
+++ b/src/articles.ts
@@ -1,13 +1,14 @@
-import { Iri, JsonLdObj } from 'jsonld/jsonld-spec';
+import { JsonLdObj } from 'jsonld/jsonld-spec';
+import { BlankNode } from 'rdf-js';
 
-interface Articles extends AsyncIterable<[Iri, JsonLdObj]> {
-  set(id: Iri, article: JsonLdObj): Promise<void>;
+interface Articles extends AsyncIterable<[BlankNode, JsonLdObj]> {
+  set(id: BlankNode, article: JsonLdObj): Promise<void>;
 
-  get(id: Iri): Promise<JsonLdObj>;
+  get(id: BlankNode): Promise<JsonLdObj>;
 
-  remove(id: Iri): Promise<void>;
+  remove(id: BlankNode): Promise<void>;
 
-  contains(id: Iri): Promise<boolean>;
+  contains(id: BlankNode): Promise<boolean>;
 
   count(): Promise<number>;
 }

--- a/src/errors/article-not-found.ts
+++ b/src/errors/article-not-found.ts
@@ -1,10 +1,10 @@
-import { Iri } from 'jsonld/jsonld-spec';
+import { BlankNode } from 'rdf-js';
 
 export default class ArticleNotFound extends Error {
-  readonly id: Iri;
+  readonly id: BlankNode;
 
-  constructor(id: Iri) {
-    super(`Article ${id} could not be found`);
+  constructor(id: BlankNode) {
+    super(`Article ${id.value} could not be found`);
 
     this.id = id;
   }

--- a/src/errors/article-not-found.ts
+++ b/src/errors/article-not-found.ts
@@ -1,10 +1,11 @@
 import { BlankNode } from 'rdf-js';
+import { termToString } from 'rdf-string';
 
 export default class ArticleNotFound extends Error {
   readonly id: BlankNode;
 
   constructor(id: BlankNode) {
-    super(`Article ${id.value} could not be found`);
+    super(`Article ${termToString(id)} could not be found`);
 
     this.id = id;
   }

--- a/src/errors/not-an-article.ts
+++ b/src/errors/not-an-article.ts
@@ -1,10 +1,11 @@
-import { Iri } from 'jsonld/jsonld-spec';
+import { Term } from 'rdf-js';
+import { termToString } from 'rdf-string';
 
 export default class NotAnArticle extends Error {
-  readonly types: Array<Iri>;
+  readonly types: Array<Term>;
 
-  constructor(types: Array<Iri> = []) {
-    super(`Article type must be http://schema.org/Article (${types.length ? `'${types.join(', ')}'` : 'none'} was given)`);
+  constructor(types: Array<Term> = []) {
+    super(`Article type must be http://schema.org/Article (${types.length ? `'${types.map(termToString).join(', ')}'` : 'none'} was given)`);
 
     this.types = types;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import dataFactory from '@rdfjs/data-model';
 import InMemoryArticles from './adaptors/in-memory-articles';
 import createApp from './app';
 import createRouter from './router';
@@ -7,6 +8,6 @@ const articles = new InMemoryArticles();
 const router = createRouter();
 const apiDocumentationPath = router.url(Routes.ApiDocumentation);
 
-const app = createApp(articles, router, apiDocumentationPath);
+const app = createApp(articles, router, apiDocumentationPath, dataFactory);
 
 app.listen(8080);

--- a/src/routes/article-list.ts
+++ b/src/routes/article-list.ts
@@ -1,6 +1,7 @@
 import all from 'it-all';
-import { Iri, JsonLdObj } from 'jsonld/jsonld-spec';
+import { JsonLdObj } from 'jsonld/jsonld-spec';
 import { Next } from 'koa';
+import { BlankNode } from 'rdf-js';
 import { hydra, rdf, schema } from 'rdf-namespaces';
 import { AppContext, AppMiddleware } from '../app';
 import Routes from './index';
@@ -24,7 +25,7 @@ export default (): AppMiddleware => (
       },
       [hydra.totalItems]: count,
       [hydra.member]: {
-        '@list': list.map((parts: [Iri, JsonLdObj]): JsonLdObj => parts[1]),
+        '@list': list.map((parts: [BlankNode, JsonLdObj]): JsonLdObj => parts[1]),
       },
     };
     response.type = 'jsonld';

--- a/test/adaptors/in-memory-articles.test.ts
+++ b/test/adaptors/in-memory-articles.test.ts
@@ -1,5 +1,7 @@
+import { blankNode, namedNode } from '@rdfjs/data-model';
 import all from 'it-all';
-import { Iri, JsonLdObj } from 'jsonld/jsonld-spec';
+import { JsonLdObj } from 'jsonld/jsonld-spec';
+import { BlankNode } from 'rdf-js';
 import InMemoryArticles from '../../src/adaptors/in-memory-articles';
 import ArticleNotFound from '../../src/errors/article-not-found';
 import NotAnArticle from '../../src/errors/not-an-article';
@@ -8,7 +10,7 @@ import createArticle from '../create-article';
 describe('in-memory articles', (): void => {
   it('can add an article', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
 
     expect(await articles.contains(id)).toBe(false);
 
@@ -19,7 +21,7 @@ describe('in-memory articles', (): void => {
 
   it('can add an article with multiple types', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
 
     await articles.set(id, {
       ...createArticle(id),
@@ -31,7 +33,7 @@ describe('in-memory articles', (): void => {
 
   it('can update an article', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
 
     await articles.set(id, createArticle(id, 'Original'));
     await articles.set(id, createArticle(id, 'Updated'));
@@ -41,17 +43,17 @@ describe('in-memory articles', (): void => {
 
   it('throws an error if it is not an article', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
 
     await expect(articles.set(id, {
       ...createArticle(id),
       '@type': 'http://schema.org/NewsArticle',
-    })).rejects.toThrow(new NotAnArticle(['http://schema.org/NewsArticle']));
+    })).rejects.toThrow(new NotAnArticle([namedNode('http://schema.org/NewsArticle')]));
   });
 
   it('throws an error if it has no type', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
 
     await expect(articles.set(id, {
       ...createArticle(id),
@@ -61,23 +63,25 @@ describe('in-memory articles', (): void => {
 
   it('can retrieve an article', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
+    const article = createArticle(id);
 
-    await articles.set(id, createArticle(id));
+    await articles.set(id, article);
 
-    expect((await articles.get(id))['@id']).toBe(id);
+    expect((await articles.get(id))).toStrictEqual(article);
   });
 
   it('throws an error if the article is not found', async (): Promise<void> => {
     const articles = new InMemoryArticles();
+    const id = blankNode();
 
-    await expect(articles.get('_:1')).rejects.toBeInstanceOf(ArticleNotFound);
-    await expect(articles.get('_:1')).rejects.toHaveProperty('id', '_:1');
+    await expect(articles.get(id)).rejects.toBeInstanceOf(ArticleNotFound);
+    await expect(articles.get(id)).rejects.toHaveProperty('id', id);
   });
 
   it('can remove an article', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
 
     await articles.set(id, createArticle(id));
     await articles.remove(id);
@@ -87,7 +91,7 @@ describe('in-memory articles', (): void => {
 
   it('does nothing when trying to remove an article that is not there', async (): Promise<void> => {
     const articles = new InMemoryArticles();
-    const id = '_:1';
+    const id = blankNode();
 
     await expect(articles.remove(id)).resolves.not.toThrow();
   });
@@ -97,8 +101,8 @@ describe('in-memory articles', (): void => {
 
     expect(await articles.count()).toBe(0);
 
-    const id1 = '_:1';
-    const id2 = '_:2';
+    const id1 = blankNode();
+    const id2 = blankNode();
 
     await articles.set(id1, createArticle(id1));
     await articles.set(id2, createArticle(id2));
@@ -110,15 +114,15 @@ describe('in-memory articles', (): void => {
   it('can iterate through the articles', async (): Promise<void> => {
     const articles = new InMemoryArticles();
 
-    const id1 = '_:1';
-    const id2 = '_:2';
-    const id3 = '_:3';
+    const id1 = blankNode();
+    const id2 = blankNode();
+    const id3 = blankNode();
 
     await articles.set(id1, createArticle(id1));
     await articles.set(id3, createArticle(id3));
     await articles.set(id2, createArticle(id2));
 
-    const ids = (await all(articles)).map((parts: [Iri, JsonLdObj]): Iri => parts[0]);
+    const ids = (await all(articles)).map((parts: [BlankNode, JsonLdObj]): BlankNode => parts[0]);
 
     expect(ids).toStrictEqual([id1, id3, id2]);
   });

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,3 +1,4 @@
+import dataFactory from '@rdfjs/data-model';
 import Koa from 'koa';
 import parseLinkHeader from 'parse-link-header';
 import request from 'supertest';
@@ -13,7 +14,7 @@ const router = createRouter();
 let app: Koa;
 
 beforeEach((): void => {
-  app = createApp(new InMemoryArticles(), router, router.url(Routes.ApiDocumentation));
+  app = createApp(new InMemoryArticles(), router, router.url(Routes.ApiDocumentation), dataFactory);
 });
 
 describe('the application', (): void => {

--- a/test/context.ts
+++ b/test/context.ts
@@ -1,4 +1,5 @@
 import Router from '@koa/router';
+import dataFactory from '@rdfjs/data-model';
 import { UnknownError } from 'http-errors';
 import { JsonLdObj } from 'jsonld/jsonld-spec';
 import Koa, { Context } from 'koa';
@@ -41,6 +42,6 @@ export default ({
   response.res = new ServerResponse();
 
   return {
-    app, articles, method, path, request, response, router,
-  } as AppContext;
+    app, articles, dataFactory, method, path, request, response, router,
+  } as unknown as AppContext;
 };

--- a/test/create-article.ts
+++ b/test/create-article.ts
@@ -1,11 +1,13 @@
 import deepFilter from 'deep-filter';
-import { Iri, JsonLdObj } from 'jsonld/jsonld-spec';
+import { JsonLdObj } from 'jsonld/jsonld-spec';
+import { BlankNode } from 'rdf-js';
+import { termToString } from 'rdf-string';
 
 const isNotUndefined = (arg: unknown): boolean => arg !== undefined;
 
-export default (id?: Iri, name = id ? `Article ${id}` : 'Article'): JsonLdObj => (
+export default (id?: BlankNode, name = id ? `Article ${id}` : 'Article'): JsonLdObj => (
   deepFilter({
-    '@id': id,
+    '@id': id ? termToString(id) : undefined,
     '@type': 'http://schema.org/Article',
     'http://schema.org/name': name,
   }, isNotUndefined)

--- a/test/errors/article-not-found.test.ts
+++ b/test/errors/article-not-found.test.ts
@@ -11,7 +11,7 @@ describe('article not found error', (): void => {
   it('should have a message', async (): Promise<void> => {
     const error = new ArticleNotFound(blankNode('12345'));
 
-    expect(error.message).toBe('Article 12345 could not be found');
+    expect(error.message).toBe('Article _:12345 could not be found');
   });
 
   it('should have an ID', async (): Promise<void> => {

--- a/test/errors/article-not-found.test.ts
+++ b/test/errors/article-not-found.test.ts
@@ -1,21 +1,23 @@
+import { blankNode } from '@rdfjs/data-model';
 import ArticleNotFound from '../../src/errors/article-not-found';
 
 describe('article not found error', (): void => {
   it('should be an error', async (): Promise<void> => {
-    const error = new ArticleNotFound('12345');
+    const error = new ArticleNotFound(blankNode());
 
     expect(error).toBeInstanceOf(Error);
   });
 
   it('should have a message', async (): Promise<void> => {
-    const error = new ArticleNotFound('12345');
+    const error = new ArticleNotFound(blankNode('12345'));
 
     expect(error.message).toBe('Article 12345 could not be found');
   });
 
   it('should have an ID', async (): Promise<void> => {
-    const error = new ArticleNotFound('12345');
+    const id = blankNode();
+    const error = new ArticleNotFound(id);
 
-    expect(error.id).toBe('12345');
+    expect(error.id).toBe(id);
   });
 });

--- a/test/errors/not-an-article.test.ts
+++ b/test/errors/not-an-article.test.ts
@@ -1,3 +1,4 @@
+import { literal, namedNode } from '@rdfjs/data-model';
 import NotAnArticle from '../../src/errors/not-an-article';
 
 describe('not an article error', (): void => {
@@ -15,9 +16,9 @@ describe('not an article error', (): void => {
   });
 
   it('may have types', async (): Promise<void> => {
-    const error = new NotAnArticle(['http://schema.org/NewsArticle', 'http://schema.org/Book']);
+    const error = new NotAnArticle([namedNode('http://schema.org/NewsArticle'), literal('book')]);
 
-    expect(error.message).toBe('Article type must be http://schema.org/Article (\'http://schema.org/NewsArticle, http://schema.org/Book\' was given)');
-    expect(error.types).toStrictEqual(['http://schema.org/NewsArticle', 'http://schema.org/Book']);
+    expect(error.message).toBe('Article type must be http://schema.org/Article (\'http://schema.org/NewsArticle, "book"\' was given)');
+    expect(error.types).toStrictEqual([namedNode('http://schema.org/NewsArticle'), literal('book')]);
   });
 });

--- a/test/routes/add-article.test.ts
+++ b/test/routes/add-article.test.ts
@@ -1,3 +1,4 @@
+import { blankNode } from '@rdfjs/data-model';
 import createHttpError from 'http-errors';
 import all from 'it-all';
 import { JsonLdObj } from 'jsonld/jsonld-spec';
@@ -29,8 +30,10 @@ describe('add article', (): void => {
   });
 
   it('should throw an error if id is already set', async (): Promise<void> => {
-    await expect(makeRequest(createArticle('_:1'))).rejects.toBeInstanceOf(createHttpError.Forbidden);
-    await expect(makeRequest(createArticle('_:1'))).rejects.toHaveProperty('message', 'Article IDs must not be set (\'_:1\' was given)');
+    const id = blankNode();
+
+    await expect(makeRequest(createArticle(id))).rejects.toBeInstanceOf(createHttpError.Forbidden);
+    await expect(makeRequest(createArticle(id))).rejects.toHaveProperty('message', `Article IDs must not be set ('_:${id.value}' was given)`);
   });
 
   it('should throw an error if it is not a schema:Article', async (): Promise<void> => {

--- a/test/routes/add-article.test.ts
+++ b/test/routes/add-article.test.ts
@@ -30,10 +30,10 @@ describe('add article', (): void => {
   });
 
   it('should throw an error if id is already set', async (): Promise<void> => {
-    const id = blankNode();
+    const id = blankNode('12345');
 
     await expect(makeRequest(createArticle(id))).rejects.toBeInstanceOf(createHttpError.Forbidden);
-    await expect(makeRequest(createArticle(id))).rejects.toHaveProperty('message', `Article IDs must not be set ('_:${id.value}' was given)`);
+    await expect(makeRequest(createArticle(id))).rejects.toHaveProperty('message', 'Article IDs must not be set (\'_:12345\' was given)');
   });
 
   it('should throw an error if it is not a schema:Article', async (): Promise<void> => {

--- a/test/routes/article-list.test.ts
+++ b/test/routes/article-list.test.ts
@@ -1,3 +1,4 @@
+import { blankNode, namedNode } from '@rdfjs/data-model';
 import jsonld from 'jsonld';
 import { Next, Response } from 'koa';
 import InMemoryArticles from '../../src/adaptors/in-memory-articles';
@@ -40,8 +41,8 @@ describe('article list', (): void => {
   it('should return articles in the list', async (): Promise<void> => {
     const articles = new InMemoryArticles();
 
-    const id1 = '_:1';
-    const id2 = '_:2';
+    const id1 = blankNode();
+    const id2 = blankNode();
 
     await articles.set(id1, createArticle(id1));
     await articles.set(id2, createArticle(id2));

--- a/test/routes/article-list.test.ts
+++ b/test/routes/article-list.test.ts
@@ -1,4 +1,4 @@
-import { blankNode, namedNode } from '@rdfjs/data-model';
+import { blankNode } from '@rdfjs/data-model';
 import jsonld from 'jsonld';
 import { Next, Response } from 'koa';
 import InMemoryArticles from '../../src/adaptors/in-memory-articles';


### PR DESCRIPTION
Currently strings are used for JSON-LD IRIs and blank node identifiers; the `Iri` type is just a string, so the two are being mixed. This introduces RDF/JS terms; while they still have to be converted to and from strings, it means the term type can be handled correctly.

Extracted from https://github.com/libero/article-store/pull/115.