### PR TITLE
Fix issue with services loop in wait-healthy

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -13,5 +13,9 @@ services:
       BASE_URL: http://localhost:8080/
     ports:
       - '8081:8000'
+    healthcheck:
+      test: wget --quiet --tries=1 --spider http://localhost:8000/ || exit 1
+      interval: 5s
+      timeout: 1s
     depends_on:
       - app

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ wait-healthy: ## Wait for the containers to be healthy
 		echo "No containers running"; \
 		exit 1; \
 	fi; \
-	for service in $${services}; do \
+	for service in $${services[@]}; do \
 		.scripts/docker/wait-healthy.sh "$${service}"; \
 	done
 


### PR DESCRIPTION
Currently, we are only checking the status of the first docker container. This ensures that all container ID's are passed to `./scripts/docker/wait-healthy.sh`.

~~Related and blocked by: https://github.com/libero/scripts/pull/15~~

If we can easily filter to only pass containers with healthchecks in place to `./scripts/docker/wait-healthy.sh` then we can close: https://github.com/libero/scripts/pull/15