### PR TITLE
Improve request and response typing in tests

### DIFF
--- a/test/context.ts
+++ b/test/context.ts
@@ -2,9 +2,9 @@ import Router from '@koa/router';
 import dataFactory from '@rdfjs/data-model';
 import { UnknownError } from 'http-errors';
 import { JsonLdObj } from 'jsonld/jsonld-spec';
-import Koa, { Context } from 'koa';
-import Request from 'koa/lib/request';
-import Response from 'koa/lib/response';
+import Koa, { Context, Request, Response } from 'koa';
+import KoaRequest from 'koa/lib/request';
+import KoaResponse from 'koa/lib/response';
 import { Request as IncomingMessage, Response as ServerResponse } from 'mock-http';
 import InMemoryArticles from '../src/adaptors/in-memory-articles';
 import { AppContext } from '../src/app';
@@ -33,11 +33,12 @@ export default ({
   const app = new Koa();
   app.on('error', errorListener || jest.fn());
 
-  const request = Object.create(Request);
-  const response = Object.create(Response);
+  const request = Object.create(KoaRequest) as Request;
   request.app = app;
   request.body = body;
   request.req = new IncomingMessage({ headers: { host: 'example.com' } });
+
+  const response = Object.create(KoaResponse) as Response;
   response.req = request.req;
   response.res = new ServerResponse();
 

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -1,18 +1,16 @@
-import { Middleware, ParameterizedContext, Response } from 'koa';
-import { AppContext, AppState } from '../src/app';
+import { ExtendableContext } from 'koa';
+import { Middleware } from 'koa-compose';
+import { AppContext } from '../src/app';
 
-export type Next<StateT = AppState, CustomT = AppContext> = (
-  context: ParameterizedContext<StateT, CustomT>
-) => Promise<void>;
+export type Next<CustomT extends ExtendableContext = AppContext> =
+  (context: CustomT) => Promise<void>;
 
-export default async <StateT = AppState, CustomT = AppContext>(
-  middleware: Middleware<StateT, CustomT>,
-  context: ParameterizedContext<StateT, CustomT>,
-  next?: Next<StateT, CustomT>,
-): Promise<Response> => {
+export default async <CustomT extends ExtendableContext>(
+  middleware: Middleware<CustomT>,
+  context: CustomT,
+  next?: Next<CustomT>,
+): Promise<CustomT['response']> => {
   await middleware(context, next ? (): Promise<void> => next(context) : jest.fn());
 
-  const { response } = context;
-
-  return response;
+  return context.response;
 };


### PR DESCRIPTION
Fixes the request and response types in the context factory, which allows the middleware runner to return the real response type. 

Refs https://github.com/libero/article-store/pull/115#discussion_r363793050.