### PR TITLE
Increase max line length to 120

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,13 @@ module.exports = {
   ],
   root: true,
   rules: {
+    'max-len': ['error', 120, 2, {
+      ignoreUrls: true,
+      ignoreComments: false,
+      ignoreRegExpLiterals: true,
+      ignoreStrings: true,
+      ignoreTemplateLiterals: true,
+    }],
     'no-undef': 'off',
   },
   settings: {


### PR DESCRIPTION
The AirBnb default is 100 characters, but 120 has been used in other projects.

Extracted from https://github.com/libero/article-store/pull/159#discussion_r364170836.