### PR TITLE
Fix next middleware type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,13 @@ module.exports = {
   ],
   root: true,
   rules: {
+    'max-len': ['error', 120, 2, {
+      ignoreUrls: true,
+      ignoreComments: false,
+      ignoreRegExpLiterals: true,
+      ignoreStrings: true,
+      ignoreTemplateLiterals: true,
+    }],
     'no-undef': 'off',
   },
   settings: {

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -1,14 +1,14 @@
 import { Middleware, ParameterizedContext, Response } from 'koa';
 import { AppContext, AppState } from '../src/app';
 
-export type Next<StateT = AppState, CustomT = AppContext> = (
+export type NextMiddleware<StateT = AppState, CustomT = AppContext> = (
   context: ParameterizedContext<StateT, CustomT>
 ) => Promise<void>;
 
 export default async <StateT = AppState, CustomT = AppContext>(
   middleware: Middleware<StateT, CustomT>,
   context: ParameterizedContext<StateT, CustomT>,
-  next?: Next<StateT, CustomT>,
+  next?: NextMiddleware<StateT, CustomT>,
 ): Promise<Response> => {
   await middleware(context, next ? (): Promise<void> => next(context) : jest.fn());
 

--- a/test/middleware/api-documentation.test.ts
+++ b/test/middleware/api-documentation.test.ts
@@ -2,9 +2,9 @@ import { Response } from 'koa';
 import parseLinkHeader from 'parse-link-header';
 import apiDocumentation from '../../src/middleware/api-documentation-link';
 import createContext from '../context';
-import runMiddleware, { Next } from '../middleware';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
-const makeRequest = async (next?: Next): Promise<Response> => (
+const makeRequest = async (next?: NextMiddleware): Promise<Response> => (
   runMiddleware(apiDocumentation('/path-to/api-documentation'), createContext(), next)
 );
 

--- a/test/middleware/empty-response.test.ts
+++ b/test/middleware/empty-response.test.ts
@@ -1,9 +1,9 @@
 import { Context, Response } from 'koa';
 import emptyResponse from '../../src/middleware/empty-response';
 import createContext from '../context';
-import runMiddleware, { Next } from '../middleware';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
-const makeRequest = async (next?: Next): Promise<Response> => (
+const makeRequest = async (next?: NextMiddleware): Promise<Response> => (
   runMiddleware(emptyResponse(), createContext(), next)
 );
 

--- a/test/middleware/error-handler.test.ts
+++ b/test/middleware/error-handler.test.ts
@@ -3,9 +3,9 @@ import jsonld from 'jsonld';
 import { Response } from 'koa';
 import errorHandler from '../../src/middleware/error-handler';
 import createContext, { ErrorListener } from '../context';
-import runMiddleware, { Next } from '../middleware';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
-const makeRequest = async (next?: Next, errorListener?: ErrorListener): Promise<Response> => {
+const makeRequest = async (next?: NextMiddleware, errorListener?: ErrorListener): Promise<Response> => {
   const context = createContext({ errorListener });
 
   return runMiddleware(errorHandler(), context, next);

--- a/test/middleware/jsonld.test.ts
+++ b/test/middleware/jsonld.test.ts
@@ -3,9 +3,9 @@ import { Context as JsonLdContext } from 'jsonld/jsonld-spec';
 import { Context, Response } from 'koa';
 import jsonld from '../../src/middleware/jsonld';
 import createContext from '../context';
-import runMiddleware, { Next } from '../middleware';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
-const makeRequest = async (next?: Next, jsonLdContext: JsonLdContext = {}): Promise<Response> => (
+const makeRequest = async (next?: NextMiddleware, jsonLdContext: JsonLdContext = {}): Promise<Response> => (
   runMiddleware(jsonld(jsonLdContext), createContext(), next)
 );
 

--- a/test/middleware/routing.test.ts
+++ b/test/middleware/routing.test.ts
@@ -3,7 +3,7 @@ import createHttpError from 'http-errors';
 import { Context, Next, Response } from 'koa';
 import routing from '../../src/middleware/routing';
 import createContext from '../context';
-import runMiddleware from '../middleware';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
 const createRouter = (): Router => {
   const router = new Router();
@@ -17,7 +17,7 @@ const createRouter = (): Router => {
   return router;
 };
 
-const makeRequest = async (method: string, path: string, next?: Next): Promise<Response> => {
+const makeRequest = async (method: string, path: string, next?: NextMiddleware): Promise<Response> => {
   const router = createRouter();
   const context = createContext({ method, path, router });
 

--- a/test/routes/add-article.test.ts
+++ b/test/routes/add-article.test.ts
@@ -2,18 +2,18 @@ import { blankNode } from '@rdfjs/data-model';
 import createHttpError from 'http-errors';
 import all from 'it-all';
 import { JsonLdObj } from 'jsonld/jsonld-spec';
-import { Next, Response } from 'koa';
+import { Response } from 'koa';
 import InMemoryArticles from '../../src/adaptors/in-memory-articles';
 import Articles from '../../src/articles';
 import { schema } from '../../src/namespaces';
 import addArticle from '../../src/routes/add-article';
 import createContext from '../context';
 import createArticle from '../create-article';
-import runMiddleware from '../middleware';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
 const makeRequest = async (
   body: JsonLdObj = {},
-  next?: Next,
+  next?: NextMiddleware,
   articles: Articles = new InMemoryArticles(),
 ): Promise<Response> => (
   runMiddleware(addArticle(), createContext({ articles, body }), next)

--- a/test/routes/api-documentation.test.ts
+++ b/test/routes/api-documentation.test.ts
@@ -1,10 +1,10 @@
 import jsonld from 'jsonld';
-import { Next, Response } from 'koa';
+import { Response } from 'koa';
 import apiDocumentation from '../../src/routes/api-documentation';
-import runMiddleware from '../middleware';
 import createContext from '../context';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
-const makeRequest = async (next?: Next): Promise<Response> => (
+const makeRequest = async (next?: NextMiddleware): Promise<Response> => (
   runMiddleware(apiDocumentation(), createContext(), next)
 );
 

--- a/test/routes/article-list.test.ts
+++ b/test/routes/article-list.test.ts
@@ -1,14 +1,14 @@
 import { blankNode } from '@rdfjs/data-model';
 import jsonld from 'jsonld';
-import { Next, Response } from 'koa';
+import { Response } from 'koa';
 import InMemoryArticles from '../../src/adaptors/in-memory-articles';
 import Articles from '../../src/articles';
 import articleList from '../../src/routes/article-list';
 import createContext from '../context';
 import createArticle from '../create-article';
-import runMiddleware from '../middleware';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
-const makeRequest = async (next?: Next, articles?: Articles): Promise<Response> => (
+const makeRequest = async (next?: NextMiddleware, articles?: Articles): Promise<Response> => (
   runMiddleware(articleList(), createContext({ articles }), next)
 );
 

--- a/test/routes/entry-point.test.ts
+++ b/test/routes/entry-point.test.ts
@@ -1,10 +1,10 @@
 import jsonld from 'jsonld';
-import { Next, Response } from 'koa';
+import { Response } from 'koa';
 import entryPoint from '../../src/routes/entry-point';
-import runMiddleware from '../middleware';
 import createContext from '../context';
+import runMiddleware, { NextMiddleware } from '../middleware';
 
-const makeRequest = async (next?: Next): Promise<Response> => (
+const makeRequest = async (next?: NextMiddleware): Promise<Response> => (
   runMiddleware(entryPoint(), createContext(), next)
 );
 


### PR DESCRIPTION
Some tests are using the wrong type for the middleware runner, this renames it so it's different from Koa's `Next` type and fixes its usage.