### PR TITLE
Don't used untyped modules

### DIFF
--- a/test/context.ts
+++ b/test/context.ts
@@ -1,8 +1,6 @@
 import Router from '@koa/router';
 import { UnknownError } from 'http-errors';
 import Koa, { Context, Request, Response } from 'koa';
-import KoaRequest from 'koa/lib/request';
-import KoaResponse from 'koa/lib/response';
 import { Request as IncomingMessage, Response as ServerResponse } from 'mock-http';
 import { DatasetCore } from 'rdf-js';
 import InMemoryArticles from '../src/adaptors/in-memory-articles';
@@ -45,7 +43,7 @@ export default ({
   const app = new Koa();
   app.on('error', errorListener || jest.fn());
 
-  const request = Object.create(KoaRequest) as WithDataset<Request>;
+  const request = Object.create(app.request) as WithDataset<Request>;
   request.app = app;
   request.dataset = requestDataset;
   request.req = new IncomingMessage({
@@ -58,7 +56,7 @@ export default ({
     method,
   });
 
-  const response = Object.create(KoaResponse) as WithDataset<Response>;
+  const response = Object.create(app.response) as WithDataset<Response>;
   response.req = request.req;
   response.res = new ServerResponse();
   response.dataset = dataset();

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,4 +1,3 @@
-import Layer from '@koa/router/lib/layer';
 import createRouter from '../src/router';
 import Routes from '../src/routes';
 
@@ -7,7 +6,7 @@ describe('router', (): void => {
 
   Object.keys(Routes).forEach((name: string): void => {
     it(`has a route named ${name}`, (): void => {
-      expect(router.route(Routes[name])).toBeInstanceOf(Layer);
+      expect(router.route(Routes[name])).toBeTruthy();
     });
   });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -6,7 +6,7 @@ describe('router', (): void => {
 
   Object.keys(Routes).forEach((name: string): void => {
     it(`has a route named ${name}`, (): void => {
-      expect(router.route(Routes[name])).toBeTruthy();
+      expect(router.route(Routes[name])).toMatchObject({ name: Routes[name] });
     });
   });
 });


### PR DESCRIPTION
Removes usage in the tests of modules that are not typed, which should not be considered public.

Refs https://github.com/libero/article-store/pull/29#issuecomment-572475448.