### PR TITLE
Fix router context

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,11 +14,11 @@ import namespaces from './namespaces';
 
 export type AppState = DefaultState;
 
-export type AppRouterContext = DatasetContext<{
+export type AppServiceContext = DatasetContext<{
   articles: Articles;
 }>;
 
-export type AppContext = RouterContext<AppState, AppRouterContext>;
+export type AppContext = RouterContext<AppState, AppServiceContext>;
 
 export type AppMiddleware = Middleware<AppState, AppContext>;
 
@@ -26,7 +26,7 @@ export type App = Koa<AppState, AppContext>
 
 export default (
   articles: Articles,
-  router: Router<AppState, AppRouterContext>,
+  router: Router<AppState, AppServiceContext>,
   apiDocumentationPath: string,
   dataFactory: ExtendedDataFactory,
 ): App => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,9 +14,11 @@ import namespaces from './namespaces';
 
 export type AppState = DefaultState;
 
-export type AppContext = RouterContext<AppState, DatasetContext<{
+export type AppRouterContext = DatasetContext<{
   articles: Articles;
-}>>;
+}>;
+
+export type AppContext = RouterContext<AppState, AppRouterContext>;
 
 export type AppMiddleware = Middleware<AppState, AppContext>;
 
@@ -24,7 +26,7 @@ export type App = Koa<AppState, AppContext>
 
 export default (
   articles: Articles,
-  router: Router<AppState, AppContext>,
+  router: Router<AppState, AppRouterContext>,
   apiDocumentationPath: string,
   dataFactory: ExtendedDataFactory,
 ): App => {

--- a/src/middleware/routing.ts
+++ b/src/middleware/routing.ts
@@ -1,12 +1,10 @@
-import Router, { RouterContext } from '@koa/router';
+import Router, { Middleware, RouterContext } from '@koa/router';
 import createHttpError from 'http-errors';
-import {
-  DefaultContextExtends, DefaultStateExtends, Middleware, Next,
-} from 'koa';
+import { DefaultContextExtends, DefaultStateExtends, Next } from 'koa';
 import compose from 'koa-compose';
 
 const notFound = <State extends DefaultStateExtends, Context extends DefaultContextExtends>
-  (): Middleware<State, RouterContext<State, Context>> => (
+  (): Middleware<State, Context> => (
     async ({ _matchedRoute }: RouterContext<State, Context>, next: Next): Promise<void> => {
       await next();
 
@@ -17,7 +15,7 @@ const notFound = <State extends DefaultStateExtends, Context extends DefaultCont
   );
 
 export default <State extends DefaultStateExtends, Context extends DefaultContextExtends>
-(router: Router<State, Context>): Middleware<State, RouterContext<State, Context>> => (
+(router: Router<State, Context>): Middleware<State, Context> => (
   compose([
     router.routes(),
     notFound<State, Context>(),

--- a/src/middleware/routing.ts
+++ b/src/middleware/routing.ts
@@ -1,11 +1,11 @@
-import Router, { Middleware, RouterContext } from '@koa/router';
+import Router, { Middleware, RouterParamContext } from '@koa/router';
 import createHttpError from 'http-errors';
 import { DefaultContextExtends, DefaultStateExtends, Next } from 'koa';
 import compose from 'koa-compose';
 
 const notFound = <State extends DefaultStateExtends, Context extends DefaultContextExtends>
   (): Middleware<State, Context> => (
-    async ({ _matchedRoute }: RouterContext<State, Context>, next: Next): Promise<void> => {
+    async ({ _matchedRoute }: RouterParamContext<State, Context>, next: Next): Promise<void> => {
       await next();
 
       if (typeof _matchedRoute === 'undefined') {

--- a/src/middleware/routing.ts
+++ b/src/middleware/routing.ts
@@ -1,22 +1,26 @@
 import Router, { RouterContext } from '@koa/router';
 import createHttpError from 'http-errors';
-import { Middleware, Next, DefaultState } from 'koa';
+import {
+  DefaultContextExtends, DefaultStateExtends, Middleware, Next,
+} from 'koa';
 import compose from 'koa-compose';
 
-const notFound = (): Middleware<DefaultState, RouterContext> => (
-  async ({ _matchedRoute }: RouterContext, next: Next): Promise<void> => {
-    await next();
+const notFound = <State extends DefaultStateExtends, Context extends DefaultContextExtends>
+  (): Middleware<State, RouterContext<State, Context>> => (
+    async ({ _matchedRoute }: RouterContext<State, Context>, next: Next): Promise<void> => {
+      await next();
 
-    if (typeof _matchedRoute === 'undefined') {
-      throw new createHttpError.NotFound();
+      if (typeof _matchedRoute === 'undefined') {
+        throw new createHttpError.NotFound();
+      }
     }
-  }
-);
+  );
 
-export default (router: Router): Middleware<DefaultState, RouterContext> => (
+export default <State extends DefaultStateExtends, Context extends DefaultContextExtends>
+(router: Router<State, Context>): Middleware<State, RouterContext<State, Context>> => (
   compose([
     router.routes(),
-    notFound(),
+    notFound<State, Context>(),
     router.allowedMethods({ throw: true }),
   ])
 );

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,13 +1,13 @@
 import Router from '@koa/router';
-import { AppContext, AppState } from './app';
+import { AppRouterContext, AppState } from './app';
 import Routes from './routes';
 import addArticle from './routes/add-article';
 import apiDocumentation from './routes/api-documentation';
 import articleList from './routes/article-list';
 import entryPoint from './routes/entry-point';
 
-export default (): Router<AppState, AppContext> => {
-  const router = new Router<AppState, AppContext>();
+export default (): Router<AppState, AppRouterContext> => {
+  const router = new Router<AppState, AppRouterContext>();
 
   router.get(Routes.ApiDocumentation, '/doc', apiDocumentation());
   router.get(Routes.ArticleList, '/articles', articleList());

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,13 +1,13 @@
 import Router from '@koa/router';
-import { AppRouterContext, AppState } from './app';
+import { AppServiceContext, AppState } from './app';
 import Routes from './routes';
 import addArticle from './routes/add-article';
 import apiDocumentation from './routes/api-documentation';
 import articleList from './routes/article-list';
 import entryPoint from './routes/entry-point';
 
-export default (): Router<AppState, AppRouterContext> => {
-  const router = new Router<AppState, AppRouterContext>();
+export default (): Router<AppState, AppServiceContext> => {
+  const router = new Router<AppState, AppServiceContext>();
 
   router.get(Routes.ApiDocumentation, '/doc', apiDocumentation());
   router.get(Routes.ArticleList, '/articles', articleList());


### PR DESCRIPTION
The Router can't know about `RouterContext`; this replaces uses its contents instead.

This becomes visible with script mode turned on.