### PR TITLE
Only run tests in the test directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  rootDir: 'test',
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },


### PR DESCRIPTION
Makes sure that only tests in the `test` directory are run.

Spotted as part of https://github.com/libero/article-store/pull/167.