### PR TITLE
Use http-status-codes library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3946,6 +3946,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
+      "integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ=="
+    },
     "humanize-number": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "content-type": "^1.0.4",
     "format-link-header": "^3.0.0",
     "http-errors": "^1.7.3",
+    "http-status-codes": "^1.4.0",
     "it-all": "^1.0.1",
     "koa": "^2.11.0",
     "koa-compose": "^4.1.0",

--- a/src/middleware/jsonld.ts
+++ b/src/middleware/jsonld.ts
@@ -1,7 +1,7 @@
 import ParserJsonld from '@rdfjs/parser-jsonld';
 import SerializerJsonld from '@rdfjs/serializer-jsonld-ext';
 import { format as formatContentType } from 'content-type';
-import { constants } from 'http2';
+import { NO_CONTENT } from 'http-status-codes';
 import { Context } from 'jsonld/jsonld-spec';
 import {
   DefaultStateExtends, Middleware, Next, Response,
@@ -10,9 +10,7 @@ import pEvent from 'p-event';
 import { fromStream, toStream } from 'rdf-dataset-ext';
 import { DatasetContext } from './dataset';
 
-const responseHasContent = (response: Response): boolean => (
-  response.body || response.status === constants.HTTP_STATUS_NO_CONTENT
-);
+const responseHasContent = (response: Response): boolean => response.body || response.status === NO_CONTENT;
 
 export default (context: Context = {}): Middleware<DefaultStateExtends, DatasetContext> => {
   const contentType = {

--- a/src/routes/add-article.ts
+++ b/src/routes/add-article.ts
@@ -1,6 +1,6 @@
 import clownface from 'clownface';
 import createHttpError from 'http-errors';
-import { constants } from 'http2';
+import { CREATED } from 'http-status-codes';
 import { Next } from 'koa';
 import { Quad } from 'rdf-js';
 import { termToString } from 'rdf-string';
@@ -45,7 +45,7 @@ export default (): AppMiddleware => (
 
     await articles.set(newId, request.dataset);
 
-    response.status = constants.HTTP_STATUS_CREATED;
+    response.status = CREATED;
     response.set('Location', url.resolve(request.origin, router.url(Routes.ArticleList)));
 
     await next();

--- a/src/routes/api-documentation.ts
+++ b/src/routes/api-documentation.ts
@@ -1,5 +1,5 @@
 import clownface, { Clownface } from 'clownface';
-import { constants } from 'http2';
+import { CREATED, OK } from 'http-status-codes';
 import { Next } from 'koa';
 import { NamedNode } from 'rdf-js';
 import { toRdf } from 'rdf-literal';
@@ -86,7 +86,7 @@ export default (): AppMiddleware => (
         add.addOut(hydra.expects, schema.Article);
         add.addOut(hydra.returns, owl.Nothing);
         add.addOut(hydra.possibleStatus, (status: Clownface): void => {
-          status.addOut(hydra.statusCode, constants.HTTP_STATUS_CREATED);
+          status.addOut(hydra.statusCode, CREATED);
           status.addOut(hydra.description, literal('If the article was added successfully', 'en'));
         });
       });
@@ -137,7 +137,7 @@ export default (): AppMiddleware => (
       });
     });
 
-    response.status = constants.HTTP_STATUS_OK;
+    response.status = OK;
 
     await next();
   }

--- a/src/routes/article-list.ts
+++ b/src/routes/article-list.ts
@@ -1,5 +1,5 @@
 import clownface, { Clownface } from 'clownface';
-import { constants } from 'http2';
+import { OK } from 'http-status-codes';
 import all from 'it-all';
 import { Next } from 'koa';
 import { addAll } from 'rdf-dataset-ext';
@@ -41,7 +41,7 @@ export default (): AppMiddleware => (
 
     await Promise.all([listPromise, countPromise]);
 
-    response.status = constants.HTTP_STATUS_OK;
+    response.status = OK;
 
     await next();
   }

--- a/src/routes/entry-point.ts
+++ b/src/routes/entry-point.ts
@@ -1,5 +1,5 @@
 import clownface, { Clownface } from 'clownface';
-import { constants } from 'http2';
+import { OK } from 'http-status-codes';
 import { Next } from 'koa';
 import { NamedNode } from 'rdf-js';
 import url from 'url';
@@ -24,7 +24,7 @@ export default (): AppMiddleware => (
       list.addOut(rdf.type, hydra.Collection);
     });
 
-    response.status = constants.HTTP_STATUS_OK;
+    response.status = OK;
 
     await next();
   }

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,3 +1,4 @@
+import { NOT_FOUND, OK } from 'http-status-codes';
 import parseLinkHeader from 'parse-link-header';
 import request from 'supertest';
 import InMemoryArticles from '../src/adaptors/in-memory-articles';
@@ -20,13 +21,13 @@ describe('the application', (): void => {
   it('should respond with 200 OK on the root', async (): Promise<void> => {
     const response = await request(app.callback()).get('/');
 
-    expect(response.status).toEqual(200);
+    expect(response.status).toBe(OK);
   });
 
   it('should respond with 404 Not Found on an unknown path', async (): Promise<void> => {
     const response = await request(app.callback()).get('/does-not-exist');
 
-    expect(response.status).toEqual(404);
+    expect(response.status).toBe(NOT_FOUND);
   });
 
   it('should support cross-origin requests', async (): Promise<void> => {

--- a/test/middleware/error-handler.test.ts
+++ b/test/middleware/error-handler.test.ts
@@ -1,5 +1,6 @@
 import { blankNode, literal, quad } from '@rdfjs/data-model';
 import createHttpError, { UnknownError } from 'http-errors';
+import { INTERNAL_SERVER_ERROR, SERVICE_UNAVAILABLE } from 'http-status-codes';
 import 'jest-rdf';
 import { Response } from 'koa';
 import { WithDataset } from '../../src/middleware/dataset';
@@ -21,7 +22,7 @@ describe('error-handler middleware', (): void => {
     it('should capture the error and return an error response', async (): Promise<void> => {
       const response = await makeRequest(next(new createHttpError.ServiceUnavailable()));
 
-      expect(response.status).toBe(503);
+      expect(response.status).toBe(SERVICE_UNAVAILABLE);
     });
 
     it('should emit the error', async (): Promise<void> => {
@@ -51,7 +52,7 @@ describe('error-handler middleware', (): void => {
     it('should capture the error and return an error response', async (): Promise<void> => {
       const response = await makeRequest(next('some-error'));
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(INTERNAL_SERVER_ERROR);
     });
 
     it('should emit the error', async (): Promise<void> => {

--- a/test/middleware/jsonld.test.ts
+++ b/test/middleware/jsonld.test.ts
@@ -1,6 +1,7 @@
 import { literal, namedNode, quad } from '@rdfjs/data-model';
 import namespace from '@rdfjs/namespace';
 import { parse as parseContentType } from 'content-type';
+import { CREATED, NO_CONTENT, OK } from 'http-status-codes';
 import 'jest-rdf';
 import { Context as JsonLdContext } from 'jsonld/jsonld-spec';
 import { addAll } from 'rdf-dataset-ext';
@@ -89,19 +90,19 @@ describe('JSON-LD middleware', (): void => {
     expect(contentType.type).toBe('application/ld+json');
     expect(contentType.parameters).toMatchObject({ profile: 'http://www.w3.org/ns/json-ld#compacted' });
     expect(response.body).toMatchObject(expected);
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(OK);
   });
 
   it('sets the response status code as 200 OK if there is a dataset', async (): Promise<void> => {
     const { response } = await makeRequest(undefined, undefined, next(undefined, quads));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(OK);
   });
 
   it('does not override the response status code', async (): Promise<void> => {
-    const { response } = await makeRequest(undefined, undefined, next(undefined, quads, undefined, 201));
+    const { response } = await makeRequest(undefined, undefined, next(undefined, quads, undefined, CREATED));
 
-    expect(response.status).toBe(201);
+    expect(response.status).toBe(CREATED);
   });
 
   it('sets the response JSON-LD body with the dataset using a context', async (): Promise<void> => {
@@ -141,10 +142,10 @@ describe('JSON-LD middleware', (): void => {
   });
 
   it('does nothing to the response if the status code is 204 No Content', async (): Promise<void> => {
-    const { response } = await makeRequest(undefined, undefined, next(undefined, quads, undefined, 204));
+    const { response } = await makeRequest(undefined, undefined, next(undefined, quads, undefined, NO_CONTENT));
 
     expect(response.headers).not.toHaveProperty('content-type');
     expect(response.body).toBe(undefined);
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(NO_CONTENT);
   });
 });

--- a/test/middleware/routing.test.ts
+++ b/test/middleware/routing.test.ts
@@ -1,5 +1,6 @@
 import Router from '@koa/router';
 import createHttpError from 'http-errors';
+import { OK } from 'http-status-codes';
 import { Context, Next, Response } from 'koa';
 import routing from '../../src/middleware/routing';
 import createContext from '../context';
@@ -9,7 +10,7 @@ const createRouter = (): Router => {
   const router = new Router();
 
   router.delete('/', async ({ response }: Context, next: Next): Promise<void> => {
-    response.status = 200;
+    response.status = OK;
 
     await next();
   });
@@ -28,7 +29,7 @@ describe('routing middleware', (): void => {
   it('should match the method and path', async (): Promise<void> => {
     const response = await makeRequest('DELETE', '/');
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(OK);
   });
 
   describe('should throw an error', (): void => {

--- a/test/routes/add-article.test.ts
+++ b/test/routes/add-article.test.ts
@@ -2,6 +2,7 @@ import {
   blankNode, literal, namedNode, quad,
 } from '@rdfjs/data-model';
 import createHttpError from 'http-errors';
+import { CREATED } from 'http-status-codes';
 import all from 'it-all';
 import { Response } from 'koa';
 import { DatasetCore } from 'rdf-js';
@@ -28,7 +29,7 @@ describe('add article', (): void => {
     const name = literal('Article');
     const response = await makeRequest(createArticle({ id, name }), undefined, articles);
 
-    expect(response.status).toBe(201);
+    expect(response.status).toBe(CREATED);
     expect(response.get('Location')).toBe('http://example.com/path-to/article-list');
     expect(await articles.count()).toBe(1);
 

--- a/test/routes/api-documentation.test.ts
+++ b/test/routes/api-documentation.test.ts
@@ -1,4 +1,5 @@
 import { namedNode, quad } from '@rdfjs/data-model';
+import { OK } from 'http-status-codes';
 import { Response } from 'koa';
 import { WithDataset } from '../../src/middleware/dataset';
 import { hydra, rdf } from '../../src/namespaces';
@@ -14,7 +15,7 @@ describe('API documentation', (): void => {
   it('should return a successful response', async (): Promise<void> => {
     const response = await makeRequest();
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(OK);
   });
 
   it('should return the API documentation', async (): Promise<void> => {

--- a/test/routes/article-list.test.ts
+++ b/test/routes/article-list.test.ts
@@ -1,4 +1,5 @@
 import { namedNode, quad } from '@rdfjs/data-model';
+import { OK } from 'http-status-codes';
 import { Response } from 'koa';
 import { toRdf } from 'rdf-literal';
 import InMemoryArticles from '../../src/adaptors/in-memory-articles';
@@ -18,7 +19,7 @@ describe('article list', (): void => {
   it('should return a successful response', async (): Promise<void> => {
     const response = await makeRequest();
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(OK);
   });
 
   it('should return an empty list', async (): Promise<void> => {

--- a/test/routes/entry-point.test.ts
+++ b/test/routes/entry-point.test.ts
@@ -1,4 +1,5 @@
 import { namedNode, quad } from '@rdfjs/data-model';
+import { OK } from 'http-status-codes';
 import { Response } from 'koa';
 import { WithDataset } from '../../src/middleware/dataset';
 import { hydra, rdf, schema } from '../../src/namespaces';
@@ -14,7 +15,7 @@ describe('entry-point', (): void => {
   it('should return a successful response', async (): Promise<void> => {
     const response = await makeRequest();
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(OK);
   });
 
   it('should return the entry point', async (): Promise<void> => {


### PR DESCRIPTION
Uses a dedicated library for HTTP status codes rather than Node's HTTP/2 module as it provides a simpler API.