### PR TITLE
Extract test middleware that always throws an error

### DIFF
--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -1,9 +1,15 @@
+import { UnknownError } from 'http-errors';
 import { ExtendableContext } from 'koa';
 import { Middleware } from 'koa-compose';
 import { AppContext } from '../src/app';
 
 export type NextMiddleware<CustomT extends ExtendableContext = AppContext> =
   (context: CustomT) => Promise<void>;
+
+export const throwingNext = <CustomT extends ExtendableContext = AppContext>
+  (error: UnknownError = new Error()): NextMiddleware<CustomT> => (): never => {
+    throw error;
+  };
 
 export default async <CustomT extends ExtendableContext>(
   middleware: Middleware<CustomT>,

--- a/test/middleware/error-handler.test.ts
+++ b/test/middleware/error-handler.test.ts
@@ -1,25 +1,21 @@
 import { blankNode, literal, quad } from '@rdfjs/data-model';
-import createHttpError, { UnknownError } from 'http-errors';
+import createHttpError from 'http-errors';
 import 'jest-rdf';
 import { Response } from 'koa';
 import { WithDataset } from '../../src/middleware/dataset';
 import errorHandler from '../../src/middleware/error-handler';
 import { hydra, rdf } from '../../src/namespaces';
 import createContext, { ErrorListener } from '../context';
-import runMiddleware, { NextMiddleware } from '../middleware';
+import runMiddleware, { NextMiddleware, throwingNext } from '../middleware';
 
 const makeRequest = async (next?: NextMiddleware, errorListener?: ErrorListener): Promise<WithDataset<Response>> => (
   runMiddleware(errorHandler(), createContext({ errorListener }), next)
 );
 
-const next = (error: UnknownError) => async (): Promise<void> => {
-  throw error;
-};
-
 describe('error-handler middleware', (): void => {
   describe('for an http error', (): void => {
     it('should capture the error and return an error response', async (): Promise<void> => {
-      const response = await makeRequest(next(new createHttpError.ServiceUnavailable()));
+      const response = await makeRequest(throwingNext(new createHttpError.ServiceUnavailable()));
 
       expect(response.status).toBe(503);
     });
@@ -28,14 +24,14 @@ describe('error-handler middleware', (): void => {
       const error = new createHttpError.ServiceUnavailable();
       const errorListener = jest.fn();
 
-      const response = await makeRequest(next(error), errorListener);
+      const response = await makeRequest(throwingNext(error), errorListener);
 
       expect(errorListener).toHaveBeenCalledTimes(1);
       expect(errorListener).toHaveBeenCalledWith(error, expect.objectContaining({ response }));
     });
 
     it('should return details about the error', async (): Promise<void> => {
-      const response = await makeRequest(next(new createHttpError.ServiceUnavailable()));
+      const response = await makeRequest(throwingNext(new createHttpError.ServiceUnavailable()));
 
       const id = blankNode();
       const expected = [
@@ -49,7 +45,7 @@ describe('error-handler middleware', (): void => {
 
   describe('for a non-http error', (): void => {
     it('should capture the error and return an error response', async (): Promise<void> => {
-      const response = await makeRequest(next('some-error'));
+      const response = await makeRequest(throwingNext());
 
       expect(response.status).toBe(500);
     });
@@ -58,14 +54,14 @@ describe('error-handler middleware', (): void => {
       const error = 'some-error';
       const errorListener = jest.fn();
 
-      const response = await makeRequest(next(error), errorListener);
+      const response = await makeRequest(throwingNext(error), errorListener);
 
       expect(errorListener).toHaveBeenCalledTimes(1);
       expect(errorListener).toHaveBeenCalledWith(error, expect.objectContaining({ response }));
     });
 
     it('should return details about the error', async (): Promise<void> => {
-      const response = await makeRequest(next('Some Error'));
+      const response = await makeRequest(throwingNext('Some Error'));
 
       const id = blankNode();
       const expected = [


### PR DESCRIPTION
Extracts the middleware used by the error handler test that always throws an error so it can be used elsewhere (https://github.com/libero/article-store/pull/184).