### PR TITLE
Update Hypertest to 0.4.1

### DIFF
--- a/.github/hypertest.sh
+++ b/.github/hypertest.sh
@@ -9,4 +9,4 @@ trap finish EXIT
 
 make start wait-healthy
 
-docker run --rm --init --network host --mount "type=bind,source=$(pwd)/test/hypertest/,destination=/tests" hydrofoil/hypertest:_0.4.0 --baseUri http://localhost:8080/
+docker run --rm --init --network host --mount "type=bind,source=$(pwd)/test/hypertest/,destination=/tests" hydrofoil/hypertest:_0.4.1 --baseUri http://localhost:8080/


### PR DESCRIPTION
Required by https://github.com/libero/article-store/pull/184.