### PR TITLE
Allow the test request to know the path

### DIFF
--- a/test/context.ts
+++ b/test/context.ts
@@ -54,6 +54,7 @@ export default ({
       host: 'example.com',
     },
     method,
+    url: path,
   });
 
   const response = Object.create(app.response) as WithDataset<Response>;


### PR DESCRIPTION
The mock request used by tests knows the host and method, but not the path. This adds it.

Required by https://github.com/libero/article-store/pull/184.