### PR TITLE
Allow dev and test environments to diverge

### DIFF
--- a/.docker/docker-compose.test.yml
+++ b/.docker/docker-compose.test.yml
@@ -5,12 +5,3 @@ services:
     build:
       target: test
     image: libero/article-store:${IMAGE_TAG:-master}-dev
-    volumes:
-      - ../.eslintignore:/app/.eslintignore
-      - ../.eslintrc.js:/app/.eslintrc.js
-      - ../jest.config.js:/app/jest.config.js
-      - ../src/:/app/src
-      - ../package.json:/app/package.json
-      - ../package-lock.json:/app/package-lock.json
-      - ../test/:/app/test
-      - ../tsconfig.json:/app/tsconfig.json

--- a/.docker/docker-compose.test.yml
+++ b/.docker/docker-compose.test.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+
+services:
+  app:
+    build:
+      target: test
+    image: libero/article-store:${IMAGE_TAG:-master}-dev
+    volumes:
+      - ../.eslintignore:/app/.eslintignore
+      - ../.eslintrc.js:/app/.eslintrc.js
+      - ../jest.config.js:/app/jest.config.js
+      - ../src/:/app/src
+      - ../package.json:/app/package.json
+      - ../package-lock.json:/app/package-lock.json
+      - ../test/:/app/test
+      - ../tsconfig.json:/app/tsconfig.json

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 SHELL = /usr/bin/env bash
 
-ifneq (${TARGET}, prod)
+ifndef TARGET
 TARGET = dev
 endif
 
@@ -68,7 +68,7 @@ fix: export TARGET = dev
 fix: ## Fix linting issues in the code
 	${DOCKER_COMPOSE} run --rm app npm run lint:fix
 
-test: export TARGET = dev
+test: export TARGET = test
 test: ## Run the tests
 	${DOCKER_COMPOSE} run --rm app npm run test
 


### PR DESCRIPTION
Moving to a [persistent storage](https://github.com/libero/article-store/pull/116) introduces the need to have a minimal setup to run unit tests. The `dev` and `prod` environments will need to, at least, have the database container as a dependency.