### PR TITLE
Fix Make exit codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test: ## Run the tests
 	${DOCKER_COMPOSE} run --rm app npm run test
 
 run:
-	${DOCKER_COMPOSE} up --abort-on-container-exit --exit-code-from app; ${DOCKER_COMPOSE} down
+	${DOCKER_COMPOSE} up --abort-on-container-exit --exit-code-from app; exit=$$?; ${DOCKER_COMPOSE} down; exit $$exit
 
 dev: export TARGET = dev
 dev: ## Build and runs the container for development


### PR DESCRIPTION
Makes sure that the real exit code is returned, rather than the exit code of `docker-compose down`. This isn't visible using `make dev` due to nodemon, but is using `make prod`.

Refs https://github.com/libero/article-store/pull/116#discussion_r372467799.