### PR TITLE
Use ECMAScript Modules rather than CommonJS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2019",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "node",
     "outDir": "build",
     "strict": true,
     "esModuleInterop": true


### PR DESCRIPTION
As the target is Node only, ES modules can be used. This produces more concise, readable, and native, imports.