### PR TITLE
Remove indentation on multiline generics

### DIFF
--- a/src/middleware/data-factory.ts
+++ b/src/middleware/data-factory.ts
@@ -4,7 +4,7 @@ import {
 import { BaseQuad, DataFactory } from 'rdf-js';
 
 export type DataFactoryContext<Context extends DefaultContextExtends = DefaultContextExtends,
-  Factory extends DataFactory<BaseQuad> = DataFactory> = Context & { dataFactory: Factory };
+Factory extends DataFactory<BaseQuad> = DataFactory> = Context & { dataFactory: Factory };
 
 export default (dataFactory: DataFactory<BaseQuad>): Middleware<DefaultStateExtends, DefaultContextExtends> => (
   async (context: DefaultContextExtends, next: Next): Promise<void> => {

--- a/src/middleware/dataset.ts
+++ b/src/middleware/dataset.ts
@@ -15,7 +15,7 @@ export type DatasetContext<Context extends DefaultContextExtends = DefaultContex
   ExtendedDataFactory<Q>>;
 
 export default (): Middleware<DefaultStateExtends, DataFactoryContext<ExtendableContext,
-  ExtendedDataFactory<BaseQuad>>> => (
+ExtendedDataFactory<BaseQuad>>> => (
   async (context: DataFactoryContext<ExtendableContext, ExtendedDataFactory<BaseQuad>>, next: Next): Promise<void> => {
     Object.assign(context.request, { dataset: context.dataFactory.dataset() });
     Object.assign(context.response, { dataset: context.dataFactory.dataset() });


### PR DESCRIPTION
Make sure that a generic which is split over multiple lines has the same indentation level.

Partially extracted from https://github.com/libero/article-store/pull/226 (triggered one of the two cases).