### PR TITLE
Remove state from middleware

### DIFF
--- a/src/middleware/api-documentation-link.ts
+++ b/src/middleware/api-documentation-link.ts
@@ -1,10 +1,9 @@
 import formatLinkHeader from 'format-link-header';
-import {
-  DefaultStateExtends, ExtendableContext, Middleware, Next,
-} from 'koa';
+import { ExtendableContext, Next } from 'koa';
+import { Middleware } from 'koa-compose';
 import url from 'url';
 
-export default (path: string): Middleware<DefaultStateExtends, ExtendableContext> => (
+export default (path: string): Middleware<ExtendableContext> => (
   async ({ request, response }: ExtendableContext, next: Next): Promise<void> => {
     await next();
 

--- a/src/middleware/data-factory.ts
+++ b/src/middleware/data-factory.ts
@@ -1,12 +1,11 @@
-import {
-  DefaultContextExtends, DefaultStateExtends, Middleware, Next,
-} from 'koa';
+import { DefaultContextExtends, Next } from 'koa';
+import { Middleware } from 'koa-compose';
 import { BaseQuad, DataFactory } from 'rdf-js';
 
 export type DataFactoryContext<Context extends DefaultContextExtends = DefaultContextExtends,
 Factory extends DataFactory<BaseQuad> = DataFactory> = Context & { dataFactory: Factory };
 
-export default (dataFactory: DataFactory<BaseQuad>): Middleware<DefaultStateExtends, DefaultContextExtends> => (
+export default (dataFactory: DataFactory<BaseQuad>): Middleware<DefaultContextExtends> => (
   async (context: DefaultContextExtends, next: Next): Promise<void> => {
     Object.assign(context, { dataFactory });
 

--- a/src/middleware/dataset.ts
+++ b/src/middleware/dataset.ts
@@ -1,6 +1,7 @@
 import {
-  DefaultContextExtends, DefaultStateExtends, ExtendableContext, Middleware, Next, Request, Response,
+  DefaultContextExtends, ExtendableContext, Next, Request, Response,
 } from 'koa';
+import { Middleware } from 'koa-compose';
 import {
   BaseQuad, DataFactory, DatasetCore, DatasetCoreFactory, Quad,
 } from 'rdf-js';
@@ -14,8 +15,7 @@ export type DatasetContext<Context extends DefaultContextExtends = DefaultContex
   DataFactoryContext<Context & { request: WithDataset<Request, Q>; response: WithDataset<Response, Q> },
   ExtendedDataFactory<Q>>;
 
-export default (): Middleware<DefaultStateExtends, DataFactoryContext<ExtendableContext,
-ExtendedDataFactory<BaseQuad>>> => (
+export default (): Middleware<DataFactoryContext<ExtendableContext, ExtendedDataFactory<BaseQuad>>> => (
   async (context: DataFactoryContext<ExtendableContext, ExtendedDataFactory<BaseQuad>>, next: Next): Promise<void> => {
     Object.assign(context.request, { dataset: context.dataFactory.dataset() });
     Object.assign(context.response, { dataset: context.dataFactory.dataset() });

--- a/src/middleware/empty-response.ts
+++ b/src/middleware/empty-response.ts
@@ -1,6 +1,5 @@
-import {
-  DefaultStateExtends, ExtendableContext, Middleware, Next, Response,
-} from 'koa';
+import { ExtendableContext, Next, Response } from 'koa';
+import { Middleware } from 'koa-compose';
 
 const makeResponseEmpty = (response: Response): void => {
   response.body = '';
@@ -8,7 +7,7 @@ const makeResponseEmpty = (response: Response): void => {
   response.remove('Content-Type');
 };
 
-export default (): Middleware<DefaultStateExtends, ExtendableContext> => (
+export default (): Middleware<ExtendableContext> => (
   async ({ response }: ExtendableContext, next: Next): Promise<void> => {
     await next();
 

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -1,7 +1,6 @@
 import createHttpError, { HttpError } from 'http-errors';
-import {
-  DefaultStateExtends, ExtendableContext, Middleware, Next,
-} from 'koa';
+import { ExtendableContext, Next } from 'koa';
+import { Middleware } from 'koa-compose';
 import { hydra, rdf } from '../namespaces';
 import { DatasetContext } from './dataset';
 
@@ -32,7 +31,7 @@ const handleHttpError = (
   response.dataset = dataset(quads);
 };
 
-export default (): Middleware<DefaultStateExtends, DatasetContext<ExtendableContext>> => (
+export default (): Middleware<DatasetContext<ExtendableContext>> => (
   async (context: DatasetContext<ExtendableContext>, next: Next): Promise<void> => {
     try {
       await next();

--- a/src/middleware/jsonld.ts
+++ b/src/middleware/jsonld.ts
@@ -3,16 +3,15 @@ import SerializerJsonld from '@rdfjs/serializer-jsonld-ext';
 import { format as formatContentType } from 'content-type';
 import { NO_CONTENT } from 'http-status-codes';
 import { Context } from 'jsonld/jsonld-spec';
-import {
-  DefaultStateExtends, Middleware, Next, Response,
-} from 'koa';
+import { Next, Response } from 'koa';
+import { Middleware } from 'koa-compose';
 import pEvent from 'p-event';
 import { fromStream, toStream } from 'rdf-dataset-ext';
 import { DatasetContext } from './dataset';
 
 const responseHasContent = (response: Response): boolean => response.body || response.status === NO_CONTENT;
 
-export default (context: Context = {}): Middleware<DefaultStateExtends, DatasetContext> => {
+export default (context: Context = {}): Middleware<DatasetContext> => {
   const contentType = {
     type: 'application/ld+json',
     parameters: { profile: 'http://www.w3.org/ns/json-ld#compacted' },


### PR DESCRIPTION
Simplifies the type of middleware returned where possible, to ease typing in test improvements.

The `Middleware` type in Koa adds state information to the type in Koa-Compose, but these middleware will have no knowledge of application state so can use the simpler form.