### PR TITLE
Wait for the Postgres container to be healthy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ start-db:
 	${DOCKER_COMPOSE} up --detach db
 
 init-db:
-	$(MAKE) start-db
+	$(MAKE) start-db wait-healthy
 	${DOCKER_COMPOSE} run --rm app npm run ${INITDB}
 
 stop: ## Stop the containers
@@ -88,7 +88,7 @@ fix: ## Fix linting issues in the code
 
 test: export TARGET = dev
 test: ## Run all the Jest tests
-	$(MAKE) start-db
+	$(MAKE) start-db wait-healthy
 	${DOCKER_COMPOSE} run --rm app npm run test; ${STOP}
 
 unit-test: export TARGET = dev
@@ -97,7 +97,7 @@ unit-test: ## Run the unit tests
 
 integration-test: export TARGET = dev
 integration-test: ## Run the integration tests
-	$(MAKE) start-db
+	$(MAKE) start-db wait-healthy
 	${DOCKER_COMPOSE} run --rm app npm run test:integration; ${STOP}
 
 api-validate: ## Run the API analysis


### PR DESCRIPTION
Some builds have been failing (eg https://github.com/libero/article-store/pull/282/checks?check_run_id=533861746), presumably due to the `initdb` script trying to be run before Postgres is ready. This adds an explicit wait for the container to be healthy before running the app.

Refs https://github.com/libero/article-store/pull/116#discussion_r372478291.