### PR TITLE
Refactor router test to use native Jest duplication

### DIFF
--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -4,9 +4,7 @@ import Routes from '../src/routes';
 describe('router', (): void => {
   const router = createRouter();
 
-  Object.values(Routes).forEach((name: string): void => {
-    it(`has a route named ${name}`, (): void => {
-      expect(router.route(name)).toMatchObject({ name });
-    });
+  it.each(Object.values(Routes))('has a route named %s', async (name: string): Promise<void> => {
+    expect(router.route(name)).toMatchObject({ name });
   });
 });


### PR DESCRIPTION
Avoids manually creating multiple tests by using `it.each()` instead.